### PR TITLE
Assets - Add bock asset features to compile dependencies and version - WIP

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -218,6 +218,16 @@ class Asset {
 	protected ?string $version = null;
 
 	/**
+	 * The compiled data for all assets already loaded.
+	 *
+	 * @since TBD
+	 *
+	 * @var array
+	 */
+	protected array $compiled_data = [];
+
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string      $slug      The asset slug.
@@ -1257,5 +1267,102 @@ class Asset {
 	 */
 	public function should_print(): bool {
 		return $this->should_print;
+	}
+
+	/**
+	 * Gets the data for a given compiled Asset.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $src The partial path to the asset.
+	 *
+	 * @return ?array
+	 */
+	public function get_compiled_data( string $src ): ?array {
+		$file = $this->get_root_path() . $this->get_path() . $src . '.asset.php';
+
+		if ( isset( $this->compiled_data[ $src ] ) ) {
+			return $this->compiled_data[ $src ];
+		}
+
+		if ( ! file_exists( $file ) ) {
+			$this->compiled_data[ $src ] = null;
+		} else {
+			$this->compiled_data[ $src ] = include $file;
+		}
+
+		return $this->compiled_data[ $src ];
+	}
+
+	/**
+	 * Gets the version for a given compiled Asset.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $src The partial path to the asset.
+	 *
+	 * @return string|null
+	 */
+	public function get_compiled_version( string $src ): ?string {
+		$data = $this->get_compiled_data( $src );
+
+		return $data['version'] ?: null;
+	}
+
+	/**
+	 * Set the version for a given compiled Asset.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $src The partial path to the asset.
+	 *
+	 * @return static
+	 */
+	public function set_compiled_version( string $src ) {
+		$version = $this->get_compiled_version( $src );
+
+		$this->version = $version ?? Config::get_version();
+
+		return $this;
+	}
+
+	/**
+	 * Gets the dependencies for a given compiled Asset.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $src The partial path to the asset.
+	 *
+	 * @return string|null
+	 */
+	public function get_compiled_dependencies( string $src ): ?array {
+		$data = $this->get_compiled_data( $src );
+
+		return $data['dependencies'] ?: [];
+	}
+
+	/**
+	 * Set block dependencies.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $src The partial path to the asset.
+	 *
+	 * @return static
+	 */
+	public function set_block_dependencies( string $src ) {
+		$block_dependencies = $this->get_compiled_dependencies( $src );
+
+		if ( empty( $block_dependencies ) ) {
+			return $this;
+		}
+
+		if ( ! empty( $this->dependencies ) && is_array( $this->dependencies ) ) {
+			$block_dependencies = array_merge( $block_dependencies, $this->dependencies );
+		}
+
+		$this->set_dependencies( ...$block_dependencies );
+
+		return $this;
 	}
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -491,14 +491,19 @@ class Asset {
 	 * @return array
 	 */
 	public function get_dependencies(): array {
-		if (
-			$this->is_compiled()
-			&& ! empty( $this->compiled['dependencies'] )
-		) {
-			return $this->compiled['dependencies'];
-		}
+	    if (
+	       $this->is_compiled()
+	       && ! empty( $this->compiled['dependencies'] )
+	    ) {
+		    return array_unique(
+		        array_merge(
+		            $this->compiled['dependencies'],
+		            $this->dependencies
+	            )
+            );
+	    }
 
-		return $this->dependencies;
+	    return $this->dependencies;
 	}
 
 	/**
@@ -1297,6 +1302,25 @@ class Asset {
 	}
 
 	/**
+	 * Set the asset as compiled.
+	 *
+	 * @since TBD
+	 *
+	 * @return static
+	 */
+	public function set_as_compiled() {
+		$file = $this->get_root_path() . $this->get_path() . $this->get_file() . '.asset.php';
+
+		if ( ! file_exists( $file ) ) {
+			return $this;
+		}
+
+		$this->compiled = require $file;
+
+		return $this;
+	}
+
+	/**
 	 * Set the compiled data for the asset.
 	 *
 	 * @since TBD
@@ -1305,7 +1329,7 @@ class Asset {
 	 *
 	 * @return static
 	 */
-	public function set_compiled_data( string $src ) {
+	public function set_compiled_path( string $src ) {
 		$file = $this->get_root_path() . $this->get_path() . $src . '.asset.php';
 
 		if ( ! file_exists( $file ) ) {

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -224,7 +224,7 @@ class Asset {
 	 *
 	 * @var array
 	 */
-	protected array $compiled_data = [];
+	protected array $compiled = [];
 
 
 	/**
@@ -491,6 +491,13 @@ class Asset {
 	 * @return array
 	 */
 	public function get_dependencies(): array {
+		if (
+			$this->is_compiled()
+			&& ! empty( $this->compiled['dependencies'] )
+		) {
+			return $this->compiled['dependencies'];
+		}
+
 		return $this->dependencies;
 	}
 
@@ -681,9 +688,18 @@ class Asset {
 	/**
 	 * Get the asset version.
 	 *
+	 * @since TBD - Add support for compiled assets.
+	 *
 	 * @return string
 	 */
 	public function get_version(): string {
+		if (
+			$this->is_compiled()
+			&& ! empty( $this->compiled['version'] )
+		) {
+			return (string) $this->compiled['version'];
+		}
+
 		return $this->version;
 	}
 
@@ -1270,98 +1286,33 @@ class Asset {
 	}
 
 	/**
-	 * Gets the data for a given compiled Asset.
+	 * Determines if the asset is compiled.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_compiled(): bool {
+		return ! empty( $this->compiled );
+	}
+
+	/**
+	 * Set the compiled data for the asset.
 	 *
 	 * @since TBD
 	 *
 	 * @param string $src The partial path to the asset.
 	 *
-	 * @return ?array
+	 * @return static
 	 */
-	public function get_compiled_data( string $src ): ?array {
+	public function set_compiled_data( string $src ) {
 		$file = $this->get_root_path() . $this->get_path() . $src . '.asset.php';
 
-		if ( isset( $this->compiled_data[ $src ] ) ) {
-			return $this->compiled_data[ $src ];
-		}
-
 		if ( ! file_exists( $file ) ) {
-			$this->compiled_data[ $src ] = null;
-		} else {
-			$this->compiled_data[ $src ] = include $file;
-		}
-
-		return $this->compiled_data[ $src ];
-	}
-
-	/**
-	 * Gets the version for a given compiled Asset.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $src The partial path to the asset.
-	 *
-	 * @return string|null
-	 */
-	public function get_compiled_version( string $src ): ?string {
-		$data = $this->get_compiled_data( $src );
-
-		return $data['version'] ?: null;
-	}
-
-	/**
-	 * Set the version for a given compiled Asset.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $src The partial path to the asset.
-	 *
-	 * @return static
-	 */
-	public function set_compiled_version( string $src ) {
-		$version = $this->get_compiled_version( $src );
-
-		$this->version = $version ?? Config::get_version();
-
-		return $this;
-	}
-
-	/**
-	 * Gets the dependencies for a given compiled Asset.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $src The partial path to the asset.
-	 *
-	 * @return array|null
-	 */
-	public function get_compiled_dependencies( string $src ): ?array {
-		$data = $this->get_compiled_data( $src );
-
-		return $data['dependencies'] ?: [];
-	}
-
-	/**
-	 * Set block dependencies.
-	 *
-	 * @since TBD
-	 *
-	 * @param string $src The partial path to the asset.
-	 *
-	 * @return static
-	 */
-	public function set_block_dependencies( string $src ) {
-		$block_dependencies = $this->get_compiled_dependencies( $src );
-
-		if ( empty( $block_dependencies ) ) {
 			return $this;
 		}
 
-		if ( ! empty( $this->dependencies ) ) {
-			$block_dependencies = array_merge( $block_dependencies, $this->dependencies );
-		}
-
-		$this->set_dependencies( ...$block_dependencies );
+		$this->compiled = require $file;
 
 		return $this;
 	}

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1333,7 +1333,7 @@ class Asset {
 	 *
 	 * @param string $src The partial path to the asset.
 	 *
-	 * @return string|null
+	 * @return array|null
 	 */
 	public function get_compiled_dependencies( string $src ): ?array {
 		$data = $this->get_compiled_data( $src );
@@ -1357,7 +1357,7 @@ class Asset {
 			return $this;
 		}
 
-		if ( ! empty( $this->dependencies ) && is_array( $this->dependencies ) ) {
+		if ( ! empty( $this->dependencies ) ) {
 			$block_dependencies = array_merge( $block_dependencies, $this->dependencies );
 		}
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1309,9 +1309,12 @@ class Asset {
 	 * @return static
 	 */
 	public function set_as_compiled() {
-		$file = $this->get_root_path() . $this->get_path() . $this->get_file() . '.asset.php';
+		$file = $this->get_root_path() . $this->get_path() . str_replace( '.js', '', $this->get_file() ) . '.asset.php';
 
 		if ( ! file_exists( $file ) ) {
+			// Set file type to empty string to prevent fatal error.
+			$this->set_type( '' );
+
 			return $this;
 		}
 


### PR DESCRIPTION
Adds methods to set dependencies and version based on complied block assets. 

Utilize the following methods when adding an asset:
Set path automatically:
```
Asset::add(
	'event-schedule-manager-speaker-list-block-js',
	'js/app/speaker-list/index.js'
	)
	->set_as_compiled()
	->add_to_group( 'event-schedule-manager-editor' )
	->register();
```
Or set the path manually:
```
Asset::add(
	'event-schedule-manager-speaker-list-block-js',
	'speaker-list-block-index.js'
	)
	->set_as_compiled()
        ->set_compiled_path( 'js/app/speaker-list/index' )
	->add_to_group( 'event-schedule-manager-editor' )
	->register();
```

Both examples assume the default asset path is in `src/resources/`