### PR TITLE
Support callables to provide the localization data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A library for managing asset registration and enqueuing in WordPress.
   * [Conditional enqueuing](#conditional-enqueuing)
   * [Firing a callback after enqueuing occurs](#firing-a-callback-after-enqueuing-occurs)
   * [Output JS data](#output-js-data)
+	  * [Using a callable to provide localization data](#using-a-callable-to-provide-localization-data)
   * [Output content before/after a JS asset is output](#output-content-beforeafter-a-js-asset-is-output)
   * [Style meta data](#style-meta-data)
 
@@ -499,6 +500,28 @@ The resulting output will be:
 Note the `my-second-script-mod` handle is overriding a specific nested
 key, `boomshakalaka.project.secondScriptData.animal`, in the `boomshakalaka.project.secondScriptData` object while
 preserving the other keys.
+
+#### Using a callable to provide localization data
+
+If you need to provide localization data dynamically, you can use a callable to do so. The callable will be called
+when the asset is enqueued and the return value will be used. The callable will be passed the asset as the first
+argument and should return an array.
+
+```php
+Asset::add( 'my-script', 'js/some-asset.js' )
+	->add_localize_script(
+		'boomshakalaka.project.myScriptData',
+		function( Asset $asset ) {
+			return [
+				'animal' => 'cat',
+				'color'  => 'orange',
+			];
+		}
+	)
+	->register();
+```
+
+Any valid callable can be used, including Closures, like in the example above.
 
 ### Output content before/after a JS asset is output
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -414,11 +414,13 @@ class Asset {
 	 * @since 1.0.0
 	 *
 	 * @param string $object_name JS object name.
-	 * @param array  $data        Data assigned to the JS object.
+	 * @param array|callable  $data Data assigned to the JS object. If a callable is passed, it will be called
+	 *                              when the asset is enqueued and the return value will be used. The callable
+	 *                              will be passed the asset as the first argument and should return an array.
 	 *
 	 * @return static
 	 */
-	public function add_localize_script( string $object_name, array $data ) {
+	public function add_localize_script( string $object_name, $data ) {
 		if ( str_contains( $object_name, '.' ) ) {
 			$this->custom_localize_script_objects[] = [ $object_name, $data ];
 		} else {

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -357,7 +357,7 @@ class Assets {
 
 				// If we have a Callable as the Localize data we execute it.
 				if ( is_callable( $localize ) ) {
-					$localize = call_user_func( $localize, $asset );
+					$localize = $localize( $asset );
 				}
 
 				wp_localize_script( $asset->get_slug(), $key, $localize );
@@ -378,6 +378,11 @@ class Assets {
 		 * Print the dot.notation namespaced objects for the asset.
 		 */
 		foreach ( $custom_localize_scripts as [$object_name, $data] ) {
+			// If we have a Callable as the Localize data we execute it.
+			if ( is_callable( $data ) ) {
+				$data = $data( $asset );
+			}
+
 			$localized_key = "{$asset->get_slug()}::{$object_name}";
 
 			if ( in_array( $localized_key, $this->localized, true ) ) {


### PR DESCRIPTION
This PR "restores" the support for `callable`s to provide the localization data in the `Asset::add_localize_script` method.

The features was already present, but "hidden" behind an `array` type cast.  

I've extended the support to dot.notation objects and tests.
