### PR TITLE
Support callable dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,18 @@ Asset::add( 'script-with-dependencies', 'js/something.js' )
 	->register();
 ```
 
+You can also specify dependencies as a callable that returns an array of dependencies, like so:
+
+```php
+Asset::add( 'script-with-dependencies', 'js/something.js' )
+	->set_dependencies( function() {
+		return [ 'jquery', 'jquery-ui', 'some-other-thing' ];
+	} )
+	->register();
+```
+
+Note that the callable will be called when the asset is enqueued, not later, when the asset is printed.
+
 #### Auto-enqueuing on an action
 To specify when to enqueue the asset, you can indicate it like so:
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Asset::add( 'script-with-dependencies', 'js/something.js' )
 	->register();
 ```
 
-Note that the callable will be called when the asset is enqueued, not later, when the asset is printed.
+Note that the callable will be executed when the asset is **_enqueued_**.
 
 #### Auto-enqueuing on an action
 To specify when to enqueue the asset, you can indicate it like so:

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -36,9 +36,9 @@ class Asset {
 	/**
 	 * The asset dependencies.
 	 *
-	 * @var array
+	 * @var array<string>|callable
 	 */
-	protected array $dependencies = [];
+	protected $dependencies = [];
 
 	/**
 	 * The asset file path.
@@ -492,9 +492,9 @@ class Asset {
 	/**
 	 * Get the asset dependencies.
 	 *
-	 * @return array
+	 * @return array<string>|callable
 	 */
-	public function get_dependencies(): array {
+	public function get_dependencies() {
 		return $this->dependencies;
 	}
 
@@ -1215,15 +1215,15 @@ class Asset {
 	/**
 	 * @since 1.0.0
 	 *
-	 * @param string ...$dependencies
+	 * @param string|callable ...$dependencies
 	 *
 	 * @return static
 	 */
-	public function set_dependencies( string ...$dependencies ) {
-		$this->dependencies = [];
-
-		foreach ( $dependencies as $dependency ) {
-			$this->add_dependency( $dependency );
+	public function set_dependencies( ...$dependencies ) {
+		if ( $dependencies[0] && is_callable( $dependencies[0] ) ) {
+			$this->dependencies = $dependencies[0];
+		} else {
+			$this->dependencies = $dependencies;
 		}
 
 		return $this;

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -705,8 +705,8 @@ class Assets {
 
 				// If the asset is a callable, we call the function,
 				// passing it the asset and expecting back an array of dependencies.
-				if ( is_callable( $asset->get_dependencies() ) ) {
-					$dependencies = call_user_func( $asset->get_dependencies(), [ $asset ] );
+				if ( is_callable( $dependencies ) ) {
+					$dependencies = $dependencies( $asset );
 				}
 
 				wp_register_script( $asset->get_slug(), $asset->get_url(), $dependencies, $asset->get_version(), $asset->is_in_footer() );


### PR DESCRIPTION
This PR add support for `callable` dependencies to bring the library to feature parity with the one currently used in the plugins.
