### PR TITLE
Include a way to ignore SCRIPT_DEBUG

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.0.0
+ * Version: 1.2.3
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -914,7 +914,7 @@ class Asset {
 		// Strip the plugin URL and make this relative.
 		$relative_location = str_replace( $base_url . '/', '', $url );
 
-		if ( $script_debug ) {
+		if ( Config::should_ignore_script_debug() || $script_debug ) {
 			// Add the actual url after having the min file added.
 			$urls[] = $relative_location;
 		}
@@ -934,7 +934,7 @@ class Asset {
 			}
 		}
 
-		if ( ! $script_debug ) {
+		if ( Config::should_ignore_script_debug() || ! $script_debug ) {
 			// Add the actual url after having the min file added.
 			$urls[] = $relative_location;
 		}

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -939,6 +939,8 @@ class Asset {
 			$urls[] = $relative_location;
 		}
 
+		$urls = array_unique( $urls );
+
 		// Check for all Urls added to the array.
 		foreach ( $urls as $partial_path ) {
 			$file_path = wp_normalize_path( "{$base_dir}/{$partial_path}" );

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -30,6 +30,13 @@ class Config {
 	protected static array $path_urls = [];
 
 	/**
+	 * Determine if we should ignore SCRIPT_DEBUG when including `.min` files in the asset loading.
+	 *
+	 * @var bool
+	 */
+	protected static bool $ignore_script_debug = false;
+
+	/**
 	 * Gets the hook prefix.
 	 *
 	 * @return string
@@ -65,6 +72,15 @@ class Config {
 	}
 
 	/**
+	 * Gets wether this project shiuld ignore SCRIPT_DEBUG.
+	 *
+	 * @return bool
+	 */
+	public static function should_ignore_script_debug(): bool {
+		return static::$ignore_script_debug;
+	}
+
+	/**
 	 * Gets the root path of the project.
 	 *
 	 * @return string
@@ -95,6 +111,8 @@ class Config {
 		static::$root_path           = '';
 		static::$path_urls           = [];
 		static::$version             = '';
+
+		static::set_ignore_script_debug( false );
 	}
 
 	/**
@@ -145,6 +163,17 @@ class Config {
 		}
 
 		static::$root_path = trailingslashit( $path );
+	}
+
+	/**
+	 * Sets the ignore script debug of the project.
+	 *
+	 * @param bool $value The value to set for ignoring SCRIPT_DEBUG.
+	 *
+	 * @return void
+	 */
+	public static function set_ignore_script_debug( bool $value ) {
+		static::$ignore_script_debug = $value;
 	}
 
 	/**

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -88,10 +88,11 @@ class AssetsTest extends AssetTestCase {
 		$this->assertTrue( wp_script_is( 'fake3-script', 'registered' ) );
 		$this->assertEquals( 'fake3-script', Assets::init()->get( 'fake3-script' )->get_slug() );
 
-		$asset = Assets::init()->get( 'fake3-script' );
-
 		// The URL will always be the minified version, since we ignore the script debug.
 		$expected_url = get_site_url() . '/wp-content/plugins/assets/tests/_data/js/fake3.min.js';
+
+		Assets::init()->remove( 'fake3-script' );
+		Asset::add( 'fake3-script', 'fake3.js' )->register();
 
 		Config::set_ignore_script_debug( true );
 
@@ -100,15 +101,18 @@ class AssetsTest extends AssetTestCase {
 
 		$this->assertEquals(
 			$expected_url,
-			$asset->get_url()
+			Assets::init()->get( 'fake3-script' )->get_url()
 		);
+
+		Assets::init()->remove( 'fake3-script' );
+		Asset::add( 'fake3-script', 'fake3.js' )->register();
 
 		$this->set_const_value( 'SCRIPT_DEBUG', true );
 		$this->assertTrue( SCRIPT_DEBUG );
 
 		$this->assertEquals(
 			$expected_url,
-			$asset->get_url()
+			Assets::init()->get( 'fake3-script' )->get_url()
 		);
 	}
 

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -80,6 +80,20 @@ class AssetsTest extends AssetTestCase {
 	/**
 	 * @test
 	 */
+	public function it_should_locate_minified_versions_of_external_assets() {
+
+		Asset::add( 'fake3-script', 'fake3.js' )->register();
+
+		$this->assertTrue( Assets::init()->exists( 'fake3-script' ) );
+		$this->assertTrue( wp_script_is( 'fake3-script', 'registered' ) );
+		$this->assertEquals( 'fake3-script', Assets::init()->get( 'fake3-script' )->get_slug() );
+
+		$this->assert_minified_found( 'fake3', true, true, true );
+	}
+
+	/**
+	 * @test
+	 */
 	public function it_should_remove_assets() {
 		Asset::add( 'my-script', 'fake.js' )->register();
 		Asset::add( 'my-style', 'fake.css' )->register();

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -80,7 +80,7 @@ class AssetsTest extends AssetTestCase {
 	/**
 	 * @test
 	 */
-	public function it_should_locate_minified_versions_of_external_assets() {
+	public function it_should_properly_locate_minified_files_when_SCRIPT_DEBUG_is_on_but_ignored() {
 
 		Asset::add( 'fake3-script', 'fake3.js' )->register();
 
@@ -88,7 +88,28 @@ class AssetsTest extends AssetTestCase {
 		$this->assertTrue( wp_script_is( 'fake3-script', 'registered' ) );
 		$this->assertEquals( 'fake3-script', Assets::init()->get( 'fake3-script' )->get_slug() );
 
-		$this->assert_minified_found( 'fake3', true, true, true );
+		$asset = Assets::init()->get( 'fake3-script' );
+
+		// The URL will always be the minified version, since we ignore the script debug.
+		$expected_url = get_site_url() . '/wp-content/plugins/assets/tests/_data/js/fake3.min.js';
+
+		Config::set_ignore_script_debug( true );
+
+		$this->set_const_value( 'SCRIPT_DEBUG', false );
+		$this->assertFalse( SCRIPT_DEBUG );
+
+		$this->assertEquals(
+			$expected_url,
+			$asset->get_url()
+		);
+
+		$this->set_const_value( 'SCRIPT_DEBUG', true );
+		$this->assertTrue( SCRIPT_DEBUG );
+
+		$this->assertEquals(
+			$expected_url,
+			$asset->get_url()
+		);
 	}
 
 	/**

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -53,15 +53,26 @@ class ConfigTest extends AssetTestCase {
 	/**
 	 * @test
 	 */
+	public function should_set_ignore_script_debug() {
+		Config::set_ignore_script_debug( true );
+
+		$this->assertTrue( Config::should_ignore_script_debug() );
+	}
+
+	/**
+	 * @test
+	 */
 	public function should_reset() {
 		Config::set_hook_prefix( 'bork' );
 		Config::set_version( '1.1.0' );
 		Config::set_path( dirname( dirname( __DIR__ ) ) );
 		Config::set_relative_asset_path( 'src/resources/' );
+		Config::set_ignore_script_debug( true );
 		Config::reset();
 
 		$this->assertEquals( 'src/assets/', Config::get_relative_asset_path() );
 		$this->assertEquals( '', Config::get_version() );
+		$this->assertFalse( Config::should_ignore_script_debug() );
 
 		try {
 			Config::get_hook_prefix();


### PR DESCRIPTION
Resolves the problem where someone has `SCRIPT_DEBUG` turned on and we do not include the non minified file, which is the case for The Events Calendar and Event Tickets since we do not want to bloat the ZIP size for customers.