### PR TITLE
Ensure paths use `/` for Windows compatibility

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.2.6
+ * Version: 1.2.8
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -131,7 +131,13 @@ class Config {
 	 * @return void
 	 */
 	public static function set_path( string $path ) {
-		$plugins_content_dir_position = strpos( $path, WP_PLUGIN_DIR );
+		$plugin_dir = WP_PLUGIN_DIR;
+
+		if ( DIRECTORY_SEPARATOR !== '/' ) {
+			$plugin_dir = str_replace( '/', DIRECTORY_SEPARATOR, $plugin_dir );
+		}
+
+		$plugins_content_dir_position = strpos( $path, $plugin_dir );
 		$themes_content_dir_position  = strpos( $path, get_theme_root() );
 
 		if (
@@ -139,7 +145,7 @@ class Config {
 			&& $themes_content_dir_position === false
 		) {
 			// Default to plugins.
-			$path = WP_PLUGIN_DIR . $path;
+			$path = $plugin_dir . $path;
 		} elseif ( $plugins_content_dir_position !== false ) {
 			$path = substr( $path, $plugins_content_dir_position );
 		} elseif ( $themes_content_dir_position !== false ) {


### PR DESCRIPTION
Forward slashes in paths are functional within WP for Windows paths, so let's just convert `\` to `/` for greater compatibility.