### PR TITLE
Adding support to setting translations for JS assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,12 @@ Note: You can provide the JS file extension (`other-asset-directory/something.js
 You can specify translations for a JS asset like so:
 
 ```php
+// Using the default path of 'languages/'.
+Asset::add( 'my-thing', 'js/something.js' )
+	->with_translations( $textdomain )
+	->register();
+
+// Specifying a different path.
 Asset::add( 'my-thing', 'js/something.js' )
 	->with_translations( $textdomain, 'relative/path/to/json/lang/files' )
 	->register();

--- a/README.md
+++ b/README.md
@@ -452,6 +452,11 @@ Asset::add( 'my-thing', 'js/something.js' )
 Asset::add( 'my-thing', 'js/something.js' )
 	->with_translations( $textdomain, 'relative/path/to/json/lang/files' )
 	->register();
+
+// Using the 'default' textdomain and the default path of 'languages/'.
+Asset::add( 'my-thing', 'js/something.js' )
+	->with_translations()
+	->register();
 ```
 
 ### Conditional enqueuing

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A library for managing asset registration and enqueuing in WordPress.
 	* [Support for wp-scripts](#support-for-wp-scripts)
 	  * [Default example](#default-example)
 	  * [Overriding the default asset file location](#overriding-the-default-asset-file-location)
+	  * [Specifying translations for a JS asset](#specifying-translations-for-a-js-asset)
   * [Conditional enqueuing](#conditional-enqueuing)
   * [Firing a callback after enqueuing occurs](#firing-a-callback-after-enqueuing-occurs)
   * [Output JS data](#output-js-data)

--- a/README.md
+++ b/README.md
@@ -438,6 +438,16 @@ Asset::add( 'my-thing', 'js/something.js' )
 
 Note: You can provide the JS file extension (`other-asset-directory/something.js`), the asset file extension (`other-asset-directory/something.asset.php`), or leave it off entirely (`other-asset-directory/something`).
 
+#### Specifying translations for a JS asset
+
+You can specify translations for a JS asset like so:
+
+```php
+Asset::add( 'my-thing', 'js/something.js' )
+	->with_translations( $textdomain, 'relative/path/to/json/lang/files' )
+	->register();
+```
+
 ### Conditional enqueuing
 
 It is rare that you will want to enqueue an asset on every page load. Luckily, you can specify a condition for when an

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -218,6 +218,20 @@ class Asset {
 	protected ?string $slug = null;
 
 	/**
+	 * The asset textdomain.
+	 *
+	 * @var string
+	 */
+	protected string $textdomain = '';
+
+	/**
+	 * Translation path.
+	 *
+	 * @var string
+	 */
+	protected string $translations_path = '';
+
+	/**
 	 * The asset type.
 	 *
 	 * @var ?string
@@ -948,6 +962,26 @@ class Asset {
 	}
 
 	/**
+	 * Get the asset textdomain.
+	 *
+	 * @return string
+	 */
+	public function get_textdomain(): string {
+		return $this->textdomain;
+	}
+
+	/**
+	 * Get the asset translation path.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @return string
+	 */
+	public function get_translation_path(): string {
+		return Config::get_path() . $this->translations_path;
+	}
+
+	/**
 	 * Get the asset style data.
 	 *
 	 * @return array
@@ -1664,6 +1698,19 @@ class Asset {
 	}
 
 	/**
+	 * Set the translation path. Alias of with_translations().
+	 *
+	 * @since 1.3.1
+	 *
+	 * @param string $textdomain The textdomain of the asset.
+	 * @param string $path Relative path to the translations directory.
+	 * @return self
+	 */
+	public function set_translations( string $textdomain, string $path ): self {
+		return $this->with_translations( $textdomain, $path );
+	}
+
+	/**
 	 * Set the asset type.
 	 *
 	 * @since 1.0.0
@@ -1698,6 +1745,28 @@ class Asset {
 	 */
 	public function use_asset_file( bool $use_asset_file = true ): self {
 		$this->use_asset_file = $use_asset_file;
+		return $this;
+	}
+
+	/**
+	 * Set the translation path.
+	 *
+	 * @since 1.3.1
+	 *
+	 * @param string $textdomain The textdomain of the asset.
+	 * @param string $path Relative path to the translations directory.
+	 *
+	 * @throws InvalidArgumentException If the asset is not a JS asset.
+	 *
+	 * @return self
+	 */
+	public function with_translations( string $textdomain, string $path ): self {
+		if ( ! $this->is_js() ) {
+			throw new InvalidArgumentException( 'Translations may only be set for JS assets.' );
+		}
+
+		$this->translations_path = $path;
+		$this->textdomain        = $textdomain;
 		return $this;
 	}
 }

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1760,7 +1760,7 @@ class Asset {
 	 *
 	 * @return self
 	 */
-	public function with_translations( string $textdomain, string $path ): self {
+	public function with_translations( string $textdomain, string $path = 'languages' ): self {
 		if ( ! $this->is_js() ) {
 			throw new InvalidArgumentException( 'Translations may only be set for JS assets.' );
 		}

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1760,7 +1760,7 @@ class Asset {
 	 *
 	 * @return self
 	 */
-	public function with_translations( string $textdomain, string $path = 'languages' ): self {
+	public function with_translations( string $textdomain = 'default', string $path = 'languages' ): self {
 		if ( ! $this->is_js() ) {
 			throw new InvalidArgumentException( 'Translations may only be set for JS assets.' );
 		}

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -713,37 +713,46 @@ class Assets {
 				continue;
 			}
 
+			$asset_slug = $asset->get_slug();
+
 			if ( 'js' === $asset->get_type() ) {
 				// Script is already registered.
-				if ( wp_script_is( $asset->get_slug(), 'registered' ) ) {
+				if ( wp_script_is( $asset_slug, 'registered' ) ) {
 					continue;
 				}
 
-				wp_register_script( $asset->get_slug(), $asset->get_url(), $asset->get_dependencies(), $asset->get_version(), $asset->is_in_footer() );
+				wp_register_script( $asset_slug, $asset->get_url(), $asset->get_dependencies(), $asset->get_version(), $asset->is_in_footer() );
 
 				// Register that this asset is actually registered on the WP methods.
 				// @phpstan-ignore-next-line
-				if ( wp_script_is( $asset->get_slug(), 'registered' ) ) {
+				if ( wp_script_is( $asset_slug, 'registered' ) ) {
 					$asset->set_as_registered();
+				}
+
+				if (
+					! empty( $asset->get_translation_path() )
+					&& ! empty( $asset->get_textdomain() )
+				) {
+					wp_set_script_translations( $asset_slug, $asset->get_textdomain(), $asset->get_translation_path() );
 				}
 			} else {
 				// Style is already registered.
-				if ( wp_style_is( $asset->get_slug(), 'registered' ) ) {
+				if ( wp_style_is( $asset_slug, 'registered' ) ) {
 					continue;
 				}
 
-				wp_register_style( $asset->get_slug(), $asset->get_url(), $asset->get_dependencies(), $asset->get_version(), $asset->get_media() );
+				wp_register_style( $asset_slug, $asset->get_url(), $asset->get_dependencies(), $asset->get_version(), $asset->get_media() );
 
 				// Register that this asset is actually registered on the WP methods.
 				// @phpstan-ignore-next-line
-				if ( wp_style_is( $asset->get_slug(), 'registered' ) ) {
+				if ( wp_style_is( $asset_slug, 'registered' ) ) {
 					$asset->set_as_registered();
 				}
 
 				$style_data = $asset->get_style_data();
 				if ( $style_data ) {
 					foreach ( $style_data as $datum_key => $datum_value ) {
-						wp_style_add_data( $asset->get_slug(), $datum_key, $datum_value );
+						wp_style_add_data( $asset_slug, $datum_key, $datum_value );
 					}
 				}
 			}

--- a/tests/_data/lang/fake1-en_US-fake1.json
+++ b/tests/_data/lang/fake1-en_US-fake1.json
@@ -1,0 +1,8 @@
+{
+	"fake1.php": {
+		"Fake plugin": ""
+	},
+	"src/fake1.php:82": {
+		"Page title": "Fake title"
+	}
+}

--- a/tests/acceptance/EnqueueJSCest.php
+++ b/tests/acceptance/EnqueueJSCest.php
@@ -17,7 +17,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake.js?ver=1.0.0' ] );
 	}
@@ -35,7 +34,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/other-asset-root/js/fake-alt.js?ver=1.0.0' ] );
 	}
@@ -52,7 +50,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/other-asset-root/js/fake-alt.js?ver=1.0.0' ] );
@@ -91,7 +88,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake-with-min.min.js?ver=1.0.0' ] );
 	}
@@ -108,7 +104,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/minified/js/fake.min.js?ver=1.0.0' ] );
@@ -127,7 +122,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->dontSeeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake.js?ver=1.0.0' ] );
 	}
@@ -143,7 +137,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake.js?ver=2.0.0' ] );
@@ -162,7 +155,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake-js-with-no-extension?ver=1.0.0' ] );
 	}
@@ -178,7 +170,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->dontSeeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake.js?ver=1.0.0' ] );
@@ -197,7 +188,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( '#fake-js-js[defer]' );
 	}
@@ -215,7 +205,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( '#fake-js-js[async]' );
 	}
@@ -232,7 +221,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( '#fake-js-js[type=module]' );
@@ -260,7 +248,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( '#fake-js-js-extra' );
 		$contents = $I->grabTextFrom( '#fake-js-js-extra' );
@@ -280,7 +267,6 @@ class EnqueueJSCest {
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
 
-
 		$I->amOnPage( '/' );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/js/fake4.js?ver=12345' ] );
 	}
@@ -297,7 +283,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( 'link', [ 'href' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/build/something.css?ver=1.0.0' ] );
@@ -316,7 +301,6 @@ class EnqueueJSCest {
 		PHP;
 
 		$I->haveMuPlugin( 'enqueue.php', $code );
-
 
 		$I->amOnPage( '/' );
 		$I->seeElement( '#fake1-js-translations' );

--- a/tests/acceptance/EnqueueJSCest.php
+++ b/tests/acceptance/EnqueueJSCest.php
@@ -303,4 +303,23 @@ class EnqueueJSCest {
 		$I->seeElement( 'link', [ 'href' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/build/something.css?ver=1.0.0' ] );
 		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/build/something.js?ver=12345' ] );
 	}
+
+	public function it_should_register_translations( AcceptanceTester $I ) {
+		$code = file_get_contents( codecept_data_dir( 'enqueue-template.php' ) );
+		$code .= <<<PHP
+		add_action( 'wp_enqueue_scripts', function() {
+			Asset::add( 'fake1', 'fake1.js' )
+				->enqueue_on( 'wp_enqueue_scripts' )
+				->with_translations( 'fake1', 'tests/_data/lang' )
+				->register();
+		}, 100 );
+		PHP;
+
+		$I->haveMuPlugin( 'enqueue.php', $code );
+
+
+		$I->amOnPage( '/' );
+		$I->seeElement( '#fake1-js-translations' );
+	}
+
 }

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -772,6 +772,32 @@ SCRIPT,
 	}
 
 	/**
+	 * @test
+	 */
+	public function it_should_register_translations() {
+		$slug = 'something-' . uniqid() . '-js';
+
+		$asset = Asset::add( $slug, 'something.js' )
+			->set_translations( 'fake1', 'tests/_data/lang' )
+			->register();
+
+		$this->assertEquals( 'fake1', $asset->get_textdomain() );
+		$this->assertEquals( dirname( dirname( __DIR__ ) ) . '/tests/_data/lang', $asset->get_translation_path() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_throw_exception_when_registering_translations_for_css() {
+		$this->expectException( \InvalidArgumentException::class );
+		$slug = 'something-' . uniqid() . '-css';
+
+		Asset::add( $slug, 'something.css' )
+			->set_translations( 'fake1', 'tests/_data/lang' )
+			->register();
+	}
+
+	/**
 	 * Evaluates if a script and style have been registered.
 	 */
 	protected function existence_assertions( $test_slug_prefix ) {


### PR DESCRIPTION
This provides a way to auto-invoke `wp_set_script_translations()` at the correct moment along with the registration of a JS file.

Resolves #20 