### PR TITLE
replace the DIRECTORY_SEPARATE with slash for other OS

### DIFF
--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -135,6 +135,8 @@ class Config {
 
 		if ( DIRECTORY_SEPARATOR !== '/' ) {
 			$plugin_dir = str_replace( DIRECTORY_SEPARATOR, '/', $plugin_dir );
+			// Because the $path passed can be a constant like plugin_dir_path( __FILE__ ), we should check and replace the slash in the $path too.
+			$path       = str_replace( DIRECTORY_SEPARATOR, '/', $path );
 		}
 
 		$plugins_content_dir_position = strpos( $path, $plugin_dir );


### PR DESCRIPTION
This PR will ensure that if the OS is not *nix, then the DIRECTORY_SEPARATOR in the $path will be parsed correctly, along with the $plugin_dir.
Problem:
```
public static function set_path( string $path ) {
    $plugin_dir = WP_PLUGIN_DIR;
    if ( DIRECTORY_SEPARATOR !== '/' ) {
        $plugin_dir = str_replace( DIRECTORY_SEPARATOR, '/', $plugin_dir );
    }
    $plugins_content_dir_position = strpos( $path, $plugin_dir );
    $themes_content_dir_position  = strpos( $path, get_theme_root() );
    ...
}
```
The `$plugin_dir` gets parsed, while the `$path` is still contains the different DS, which will make the check` $plugins_content_dir_position = strpos( $path, $plugin_dir );`  always false, such as C:\sites\... vs C:/sites/...