### PR TITLE
Allow paths outside of theme and plugins

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.0
+ * Version: 1.4.1
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -146,6 +146,7 @@ class Config {
 		static::$root_path           = '';
 		static::$path_urls           = [];
 		static::$version             = '';
+		Utils::clear_runtime_cache();
 	}
 
 	/**
@@ -195,7 +196,7 @@ class Config {
 	/**
 	 * Normalizes a path.
 	 *
-	 * @since 1.4.0
+	 * @since 1.4.1
 	 *
 	 * @param string $path The path to normalize.
 	 *
@@ -212,8 +213,8 @@ class Config {
 			$plugins_content_dir_position === false
 			&& $themes_content_dir_position === false
 		) {
-			// Default to plugins.
-			$path = $plugin_dir . $path;
+			// Default to path.
+			$path = $path;
 		} elseif ( $plugins_content_dir_position !== false ) {
 			$path = substr( $path, $plugins_content_dir_position );
 		} elseif ( $themes_content_dir_position !== false ) {

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -196,7 +196,8 @@ class Config {
 	/**
 	 * Normalizes a path.
 	 *
-	 * @since 1.4.1
+	 * @since 1.4.0
+	 * @since 1.4.1 Allow for paths that are not in the plugin or theme directory.
 	 *
 	 * @param string $path The path to normalize.
 	 *

--- a/src/Assets/Utils.php
+++ b/src/Assets/Utils.php
@@ -102,6 +102,17 @@ class Utils {
 	}
 
 	/**
+	 * Clears the runtime cache.
+	 *
+	 * @since 1.4.1
+	 *
+	 * @return void
+	 */
+	public static function clear_runtime_cache() {
+		static::$bases = [];
+	}
+
+	/**
 	 * Get the runtime cache key.
 	 *
 	 * @since 1.2.3

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -38,7 +38,7 @@ class ConfigTest extends AssetTestCase {
 	 */
 	public function should_set_root_path_correctly( $path, $expected ) {
 		Config::set_path( $path );
-		$this->assertEquals( $expected, Config::get_path( $path ) );
+		$this->assertEquals( $expected, Config::get_path( $path ), Config::get_path( $path ) );
 	}
 
 	/**

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -24,10 +24,10 @@ class ConfigTest extends AssetTestCase {
 	}
 
 	public function paths_provider() {
-		yield 'plugin' => [ WP_PLUGIN_DIR . 'assets/', '/var/www/html/wp-content/plugins/assets/' ];
-		yield 'theme' => [ get_theme_file_path() . 'assets/', get_theme_file_path() . '/var/www/html/wp-content/themes/assets/' ];
-		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . 'assets/', '/var/www/html/wp-content/mu-plugins/assets/' ];
-		yield 'content' => [ WP_CONTENT_DIR . 'assets/', '/var/www/html/wp-content/assets/' ];
+		yield 'plugin' => [ WP_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/plugins/assets/' ];
+		yield 'theme' => [ get_theme_file_path() . '/assets/', get_theme_file_path() . '/var/www/html/wp-content/themes/assets/' ];
+		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/mu-plugins/assets/' ];
+		yield 'content' => [ WP_CONTENT_DIR . '/assets/', '/var/www/html/wp-content/assets/' ];
 		yield 'root' => [ ABSPATH . 'assets/', '/var/www/html/assets/' ];
 		yield 'relative' => [ 'src/resources/', 'src/resources/' ];
 	}
@@ -36,7 +36,7 @@ class ConfigTest extends AssetTestCase {
 	 * @test
 	 * @dataProvider paths_provider
 	 */
-	public function should_normalize_path( $path, $expected ) {
+	public function should_set_root_path_correctly( $path, $expected ) {
 		Config::set_path( $path );
 		$this->assertEquals( $expected, Config::get_path( $path ) );
 	}

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -35,6 +35,15 @@ class ConfigTest extends AssetTestCase {
 	/**
 	 * @test
 	 */
+	public function should_set_path_outside_of_themes_and_plugins() {
+		Config::set_path( ABSPATH . 'foo/' );
+
+		$this->assertEquals( '/var/www/html/foo/', Config::get_path() );
+	}
+
+	/**
+	 * @test
+	 */
 	public function should_set_relative_asset_path() {
 		Config::set_relative_asset_path( 'src/resources' );
 

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -25,7 +25,7 @@ class ConfigTest extends AssetTestCase {
 
 	public function paths_provider() {
 		yield 'plugin' => [ WP_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/plugins/assets/' ];
-		yield 'theme' => [ get_theme_file_path() . '/assets/', get_theme_file_path() . '/var/www/html/wp-content/themes/assets/' ];
+		yield 'theme' => [ get_theme_file_path() . '/assets/', get_theme_file_path() . '/assets/' ];
 		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/mu-plugins/assets/' ];
 		yield 'content' => [ WP_CONTENT_DIR . '/assets/', '/var/www/html/wp-content/assets/' ];
 		yield 'root' => [ ABSPATH . 'assets/', '/var/www/html/assets/' ];

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -23,6 +23,24 @@ class ConfigTest extends AssetTestCase {
 		$this->assertEquals( 'bork', Config::get_hook_prefix() );
 	}
 
+	public function paths_provider() {
+		yield 'plugin' => [ WP_PLUGIN_DIR . 'assets/', '/var/www/html/wp-content/plugins/assets/' ];
+		yield 'theme' => [ get_theme_file_path() . 'assets/', get_theme_file_path() . '/var/www/html/wp-content/themes/assets/' ];
+		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . 'assets/', '/var/www/html/wp-content/mu-plugins/assets/' ];
+		yield 'content' => [ WP_CONTENT_DIR . 'assets/', '/var/www/html/wp-content/assets/' ];
+		yield 'root' => [ ABSPATH . 'assets/', '/var/www/html/assets/' ];
+		yield 'relative' => [ 'src/resources/', 'src/resources/' ];
+	}
+
+	/**
+	 * @test
+	 * @dataProvider paths_provider
+	 */
+	public function should_normalize_path( $path, $expected ) {
+		Config::set_path( $path );
+		$this->assertEquals( $expected, Config::get_path( $path ) );
+	}
+
 	/**
 	 * @test
 	 */


### PR DESCRIPTION
Allow paths to be set outside of themes and plugins.
Imagine the following scenario:

I have a directory in ABSPATH . 'foo/'
Inside that directory i have all of my plugins. Including TEC.
BUT i also have a symlink in ABSPATH . 'wp-content/plugins/' which points to ABSPATH . 'foo/'


That should be allowed.

The issue was discovered by tests in this PR https://github.com/the-events-calendar/tribe-common/pull/2258