### PR TITLE
Prefix Config::set_path() when path is relative

### DIFF
--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -213,9 +213,10 @@ class Config {
 		if (
 			$plugins_content_dir_position === false
 			&& $themes_content_dir_position === false
+			&& strpos( $path, '/' ) !== 0
 		) {
-			// Default to path.
-			$path = $path;
+			// Default to plugins if a relative path is provided.
+			$path = trailingslashit( $plugin_dir ) . $path;
 		} elseif ( $plugins_content_dir_position !== false ) {
 			$path = substr( $path, $plugins_content_dir_position );
 		} elseif ( $themes_content_dir_position !== false ) {

--- a/tests/wpunit/ConfigTest.php
+++ b/tests/wpunit/ConfigTest.php
@@ -24,12 +24,12 @@ class ConfigTest extends AssetTestCase {
 	}
 
 	public function paths_provider() {
-		yield 'plugin' => [ WP_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/plugins/assets/' ];
-		yield 'theme' => [ get_theme_file_path() . '/assets/', get_theme_file_path() . '/assets/' ];
-		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . '/assets/', '/var/www/html/wp-content/mu-plugins/assets/' ];
-		yield 'content' => [ WP_CONTENT_DIR . '/assets/', '/var/www/html/wp-content/assets/' ];
-		yield 'root' => [ ABSPATH . 'assets/', '/var/www/html/assets/' ];
-		yield 'relative' => [ 'src/resources/', 'src/resources/' ];
+		yield 'plugin' => [ WP_PLUGIN_DIR . '/my-plugin/', '/var/www/html/wp-content/plugins/my-plugin/' ];
+		yield 'theme' => [ get_theme_file_path() . '/', get_theme_file_path() . '/' ];
+		yield 'mu-plugin' => [ WPMU_PLUGIN_DIR . '/my-plugin/', '/var/www/html/wp-content/mu-plugins/my-plugin/' ];
+		yield 'content' => [ WP_CONTENT_DIR . '/stuff/', '/var/www/html/wp-content/stuff/' ];
+		yield 'root' => [ ABSPATH . 'stuff/', '/var/www/html/stuff/' ];
+		yield 'relative' => [ 'my-plugin/', '/var/www/html/wp-content/plugins/my-plugin/' ];
 	}
 
 	/**


### PR DESCRIPTION
This ensures that if an absolute path is set during `Config::set_path()`, the library respects that full path rather than attempting to prefix it.

This builds on top of the work by @dpanta94 in #25