### PR TITLE
Handle later calls to the add_to_group_path method

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -622,13 +622,13 @@ class Asset {
 
 		$script_debug = defined( 'SCRIPT_DEBUG' ) && Utils::is_truthy( SCRIPT_DEBUG );
 
-		if ( $script_debug && file_exists( wp_normalize_path( $root_path . $resource_path . $resource ) ) ) {
+		if ( $script_debug && is_file( wp_normalize_path( $root_path . $resource_path . $resource ) ) ) {
 			return $original_url;
 		}
 
 		$minified_abs_file_path = wp_normalize_path( $root_path . $minified_file_path );
 
-		if ( ! file_exists( $minified_abs_file_path ) ) {
+		if ( ! is_file( $minified_abs_file_path ) ) {
 			return $original_url;
 		}
 
@@ -1140,7 +1140,7 @@ class Asset {
 			return false;
 		}
 
-		return file_exists( $asset_file_path );
+		return is_file( $asset_file_path );
 	}
 
 	/**
@@ -1381,7 +1381,7 @@ class Asset {
 			$file_path = wp_normalize_path( "{$base_dir}/{$partial_path}" );
 			$file_url  = "{$base_url}/{$partial_path}";
 
-			if ( file_exists( $file_path ) ) {
+			if ( is_file( $file_path ) ) {
 				return $file_url;
 			}
 		}

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -188,9 +188,9 @@ class Asset {
 	 *
 	 * In the case where the `$group_path_over_root_path` property is true, the order of priority will change to this:
 	 *
-	 * 1. If a specific root path is set, that will be used.
-	 * 2. Otherwise, the root path will be used.
-	 * 3. If a path group is set, that will be used.
+	 * 1. If a path group is set, that will be used.
+	 * 2. If a specific root path is set, that will be used.
+	 * 3. Otherwise, the root path will be used.
 	 *
 	 * @var string
 	 */

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -186,6 +186,12 @@ class Asset {
 	 * 2. If a path group is set, that will be used.
 	 * 3. Otherwise, the root path will be used.
 	 *
+	 * In the case where the `$group_path_over_root_path` property is true, the order of priority will change to this:
+	 *
+	 * 1. If a specific root path is set, that will be used.
+	 * 2. Otherwise, the root path will be used.
+	 * 3. If a path group is set, that will be used.
+	 *
 	 * @var string
 	 */
 	protected string $group_path_name = '';

--- a/tests/wpunit/AssetTest.php
+++ b/tests/wpunit/AssetTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace wpunit;
+
+use StellarWP\Assets\Asset;
+use StellarWP\Assets\Config;
+use StellarWP\Assets\Tests\AssetTestCase;
+
+class AssetTest extends AssetTestCase {
+	public function test_add_to_group_path_changes_resolution_path_to_group(): void {
+		Config::reset();
+		Config::set_hook_prefix( 'bork' );
+		Config::set_version( '1.1.0' );
+		Config::set_path( constant( 'WP_PLUGIN_DIR' ) . '/assets' );
+		Config::set_relative_asset_path( 'tests/_data/' );
+		Config::add_group_path( 'fake-group', constant( 'WP_PLUGIN_DIR' ) . '/some-plugin/build', '/' );
+
+		$asset = new Asset( 'test-script', 'fake.js', '1.0.0', codecept_data_dir() );
+
+		$this->assertEquals( WP_PLUGIN_DIR . '/assets/tests/_data/', $asset->get_root_path() );
+
+		// Now add the asset to a group path.
+		$asset->add_to_group_path( 'fake-group' );
+
+		// The asset root path will change to the group path.
+		$this->assertEquals( WP_PLUGIN_DIR . '/some-plugin/build/', $asset->get_root_path() );
+
+		$asset->remove_from_group_path( 'fake-group' );
+
+		$this->assertEquals( WP_PLUGIN_DIR . '/assets/tests/_data/', $asset->get_root_path() );
+	}
+}

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -971,7 +971,7 @@ SCRIPT,
 		$plugins_path = str_replace( constant( 'WP_CONTENT_DIR' ), '', constant( 'WP_PLUGIN_DIR' ) );
 
 		if ( constant( 'WP_PLUGIN_DIR' ) !== constant( 'WP_CONTENT_DIR' ) . $plugins_path || strpos( constant( 'ABSPATH' ), 'C:') === 0 || $wont_figure_out_min_vs_unmin ) {
-			// If we are testing outside of the actual plugin directory, the file_exists will always fail.
+			// If we are testing outside of the actual plugin directory, the `is_file` check will always fail.
 			// In installations where this set up is the actual, the file should exist.
 			// In this case it will always fail to locate mins.
 			$urls = array_map(


### PR DESCRIPTION
While the `Asset::add_to_group_path()` method _should_ be used while the
Asset is being registered, nothing currently prevents (e.g. an
exception) the method from being called on the `Asset` object after
registration.

Since the path resolution in the `get_root_path` method is done
lazily, when the method is called, the fact the Asset has been added to
a specific group path should matter.

This updates the code to support correctly, in my opinion, calls to the
`Asset::add_to_group_path` method after the object registration and take
the group path into account when resolving the root path.

See the test in this PR to have a better understanding.
