### PR TITLE
False by default for asset file for styles

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.2
+ * Version: 1.4.4
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -269,6 +269,8 @@ class Asset {
 	/**
 	 * Whether or not to attempt to load an .asset.php file.
 	 *
+	 * By default is true for scripts and false for styles.
+	 *
 	 * @since 1.3.1
 	 *
 	 * @var bool
@@ -1173,12 +1175,14 @@ class Asset {
 	 * Set the asset type.
 	 *
 	 * @since 1.0.0
+	 * @since TBD - For css files, we dont want to use asset file for dependencies by default.
 	 */
 	protected function infer_type() {
 		if ( substr( $this->file, -3, 3 ) === '.js' ) {
 			$this->type = 'js';
 		} elseif ( substr( $this->file, -4, 4 ) === '.css' ) {
 			$this->type = 'css';
+			$this->use_asset_file( false );
 		}
 	}
 

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -289,7 +289,7 @@ class Asset {
 	 * This flag will be raised when the asset is added to a group path
 	 * and lowered when it's removed from it.
 	 *
-	 * @since TBD
+	 * @since 1.4.3
 	 *
 	 * @var bool
 	 */
@@ -1175,7 +1175,7 @@ class Asset {
 	 * Set the asset type.
 	 *
 	 * @since 1.0.0
-	 * @since TBD - For css files, we dont want to use asset file for dependencies by default.
+	 * @since 1.4.4 - For css files, we dont want to use asset file for dependencies by default.
 	 */
 	protected function infer_type() {
 		if ( substr( $this->file, -3, 3 ) === '.js' ) {
@@ -1534,7 +1534,7 @@ class Asset {
 	/**
 	 * Set the asset file path for the asset.
 	 *
-	 * @since TBD
+	 * @since 1.3.0
 	 *
 	 * @param string $path The partial path to the asset.
 	 *

--- a/tests/acceptance/EnqueueCSSCest.php
+++ b/tests/acceptance/EnqueueCSSCest.php
@@ -257,11 +257,31 @@ class EnqueueCSSCest {
 		$I->dontSeeElement( 'link', [ 'href' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/css/fake.css?ver=1.0.0', 'media' => 'screen' ] );
 	}
 
+	public function it_should_enqueue_css_on_default_version_when_using_register_with_js( AcceptanceTester $I ) {
+		$code = file_get_contents( codecept_data_dir( 'enqueue-template.php' ) );
+		$code .= <<<PHP
+		add_action( 'wp_enqueue_scripts', function() {
+			Asset::add( 'something-css' . uniqid(), 'something.css' )
+				->set_path( 'tests/_data/build' )
+				->enqueue_on( 'wp_enqueue_scripts' )
+				->register_with_js();
+		}, 100 );
+		PHP;
+
+		$I->haveMuPlugin( 'enqueue.php', $code );
+
+
+		$I->amOnPage( '/' );
+		$I->seeElement( 'link', [ 'href' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/build/something.css?ver=1.0.0' ] );
+		$I->seeElement( 'script', [ 'src' => 'http://wordpress.test/wp-content/plugins/assets/tests/_data/build/something.js?ver=1.0.0' ] );
+	}
+
 	public function it_should_enqueue_js_when_using_register_with_js( AcceptanceTester $I ) {
 		$code = file_get_contents( codecept_data_dir( 'enqueue-template.php' ) );
 		$code .= <<<PHP
 		add_action( 'wp_enqueue_scripts', function() {
 			Asset::add( 'something-css' . uniqid(), 'something.css' )
+				->use_asset_file( true )
 				->set_path( 'tests/_data/build' )
 				->enqueue_on( 'wp_enqueue_scripts' )
 				->register_with_js();

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -637,28 +637,36 @@ SCRIPT,
 	/**
 	 * @test
 	 */
-	public function it_should_use_include_css_asset_file_dependencies_when_no_dependencies_are_set(): void {
+	public function it_should_not_use_include_css_asset_file_dependencies_when_no_dependencies_are_set(): void {
 		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' );
 
-		$this->assertContains( 'some-dependency', $asset->get_dependencies() );
+		$this->assertEmpty( $asset->get_dependencies() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_use_include_css_asset_file_dependencies_when_no_dependencies_are_set(): void {
+		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' )->use_asset_file( true );
+
+		$this->assertEquals( ['some-dependency'], $asset->get_dependencies() );
 	}
 
 	/**
 	 * @test
 	 */
 	public function it_should_use_include_css_asset_file_dependencies_when_dependencies_are_set(): void {
-		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' );
+		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' )->use_asset_file( true );
 		$asset->set_dependencies( 'fake1' );
 
-		$this->assertContains( 'fake1', $asset->get_dependencies() );
-		$this->assertContains( 'some-dependency', $asset->get_dependencies() );
+		$this->assertEquals( [ 'some-dependency', 'fake1' ], $asset->get_dependencies() );
 	}
 
 	/**
 	 * @test
 	 */
 	public function it_should_use_include_css_asset_file_dependencies_when_dependencies_are_set_as_callable(): void {
-		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' );
+		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' )->use_asset_file( true );
 		$asset->set_dependencies( static function() {
 			return [ 'fake1' ];
 		} );
@@ -670,8 +678,17 @@ SCRIPT,
 	/**
 	 * @test
 	 */
-	public function it_should_use_css_asset_file_version_when_no_version_is_set(): void {
+	public function it_should_not_use_css_asset_file_version_when_no_version_is_set(): void {
 		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' );
+
+		$this->assertEquals( '1.0.0', $asset->get_version() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_use_css_asset_file_version_when_no_version_is_set(): void {
+		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css' )->use_asset_file( true );
 
 		$this->assertEquals( '12345', $asset->get_version() );
 	}
@@ -680,7 +697,7 @@ SCRIPT,
 	 * @test
 	 */
 	public function it_should_use_css_asset_file_version_when_version_is_set(): void {
-		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css', '1.0' );
+		$asset = Asset::add( 'my-style' . uniqid(), 'fake4.css', '1.0' )->use_asset_file( true );
 
 		$this->assertEquals( '12345', $asset->get_version() );
 	}


### PR DESCRIPTION
This PR undos that all files should use by default their asset file if present.

Is not that rare naming a js file and css file with the actual same file name e.g. `onboarding.js` and `onboarding.css`.

As a result the `onboarding.asset.php` file would be applicable for both of those files prior this PR.

Resulting, most possibly, in the css file not being enqueued.

Thus the decision to set by default `false` to using asset file for styles, while keeping it as `true` for scripts.