### PR TITLE
Prevent assets from being added to assets array twice

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
   "description": "A library for managing asset registration and enqueuing in WordPress.",
   "type": "library",
   "license": "GPL-2.0",
+  "config": {
+    "platform": {
+      "php": "7.4"
+    }
+  },
   "autoload": {
     "psr-4": {
       "StellarWP\\Assets\\": "src/Assets/"
@@ -24,7 +29,9 @@
     }
   ],
   "minimum-stability": "stable",
-  "require": {},
+  "require": {
+    "php": ">=7.4"
+  },
   "require-dev": {
     "codeception/module-asserts": "^1.0",
     "codeception/module-cli": "^1.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,6 +16,7 @@ parameters:
 	inferPrivatePropertyTypeFromConstructor: true
 	reportUnmatchedIgnoredErrors: false
 	checkGenericClassInNonGenericObjectType: false
+	treatPhpDocTypesAsCertain: false
 
 	# Paths to be analyzed.
 	paths:

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -688,9 +688,16 @@ class Assets {
 		)
 		) {
 			// Registering the asset now would trigger a doing_it_wrong notice: queue the assets to be registered later.
+			if ( $assets === null ) {
+				return;
+			}
 
 			if ( ! is_array( $assets ) ) {
-				$assets = [ $assets ];
+				if ( ! $assets instanceof Asset ) {
+					throw new \InvalidArgumentException( 'Assets in register_in_wp() must be of type Asset' );
+				}
+
+				$assets = [ $assets->get_slug() => $assets ];
 			}
 
 			// Register later, avoid the doing_it_wrong notice.

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -405,7 +405,7 @@ class AssetsTest extends AssetTestCase {
 		     ->register();
 
 		$this->assertEquals( <<< SCRIPT
-<script id='my-first-script-js-extra'>
+<script id="my-first-script-js-extra">
 var boomshakalakaProjectFirstScriptData = {"animal":"cat","color":"orange"};
 </script>
 
@@ -413,7 +413,7 @@ SCRIPT,
 			apply_filters( 'script_loader_tag', '', 'my-first-script' )
 		);
 		$this->assertEquals( <<< SCRIPT
-<script id='my-second-script-js-extra'>
+<script id="my-second-script-js-extra">
 var boomshakalakaProjectSecondScriptData = {"animal":"dog","color":"green"};
 </script>
 
@@ -422,7 +422,7 @@ SCRIPT,
 		);
 
 		$this->assertEquals( <<< SCRIPT
-<script id='my-second-script-mod-js-extra'>
+<script id="my-second-script-mod-js-extra">
 var boomshakalakaProjectSecondScriptModData = {"animal":"horse"};
 </script>
 
@@ -504,7 +504,7 @@ SCRIPT,
 
 		$apply_filters = apply_filters( 'script_loader_tag', '', 'my-test-script' );
 		$this->assertEquals( <<< SCRIPT
-<script id='my-test-script-js-extra'>
+<script id="my-test-script-js-extra">
 var boomshakalakaProjectTestScriptData = {"animal":"cat","color":"orange"};
 </script>
 <script id="my-test-script-ns-extra">
@@ -552,7 +552,7 @@ SCRIPT,
 
 		$apply_filters = apply_filters( 'script_loader_tag', '', 'my-script-with-closure-data' );
 		$this->assertEquals( <<< SCRIPT
-<script id='my-script-with-closure-data-js-extra'>
+<script id="my-script-with-closure-data-js-extra">
 var scriptWithClosureData = {"animal":"cat","color":"orange"};
 </script>
 <script id="my-script-with-closure-data-ns-extra">
@@ -587,9 +587,9 @@ SCRIPT,
 		ob_start();
 		do_action( 'test_action' );
 		$this->assertEquals( <<< SCRIPT
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script.js?ver=1.0.0' id='my-deps-base-script-js'></script>
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script.js?ver=1.0.0' id='my-deps-vendor-script-js'></script>
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script.js?ver=1.0.0' id='my-deps-dependent-script-js'></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script.js?ver=1.0.0" id="my-deps-base-script-js"></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script.js?ver=1.0.0" id="my-deps-vendor-script-js"></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script.js?ver=1.0.0" id="my-deps-dependent-script-js"></script>
 
 SCRIPT,
 			ob_get_clean()
@@ -625,9 +625,9 @@ SCRIPT,
 		ob_start();
 		do_action( 'test_action_2' );
 		$this->assertEquals( <<< SCRIPT
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script-2.js?ver=1.0.0' id='my-base-script-2-js'></script>
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script-2.js?ver=1.0.0' id='my-vendor-script-2-js'></script>
-<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script-2.js?ver=1.0.0' id='my-dependent-script-2-js'></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script-2.js?ver=1.0.0" id="my-base-script-2-js"></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script-2.js?ver=1.0.0" id="my-vendor-script-2-js"></script>
+<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script-2.js?ver=1.0.0" id="my-dependent-script-2-js"></script>
 
 SCRIPT,
 			ob_get_clean()

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -405,7 +405,7 @@ class AssetsTest extends AssetTestCase {
 		     ->register();
 
 		$this->assertEquals( <<< SCRIPT
-<script id="my-first-script-js-extra">
+<script id='my-first-script-js-extra'>
 var boomshakalakaProjectFirstScriptData = {"animal":"cat","color":"orange"};
 </script>
 
@@ -413,7 +413,7 @@ SCRIPT,
 			apply_filters( 'script_loader_tag', '', 'my-first-script' )
 		);
 		$this->assertEquals( <<< SCRIPT
-<script id="my-second-script-js-extra">
+<script id='my-second-script-js-extra'>
 var boomshakalakaProjectSecondScriptData = {"animal":"dog","color":"green"};
 </script>
 
@@ -422,7 +422,7 @@ SCRIPT,
 		);
 
 		$this->assertEquals( <<< SCRIPT
-<script id="my-second-script-mod-js-extra">
+<script id='my-second-script-mod-js-extra'>
 var boomshakalakaProjectSecondScriptModData = {"animal":"horse"};
 </script>
 
@@ -504,7 +504,7 @@ SCRIPT,
 
 		$apply_filters = apply_filters( 'script_loader_tag', '', 'my-test-script' );
 		$this->assertEquals( <<< SCRIPT
-<script id="my-test-script-js-extra">
+<script id='my-test-script-js-extra'>
 var boomshakalakaProjectTestScriptData = {"animal":"cat","color":"orange"};
 </script>
 <script id="my-test-script-ns-extra">
@@ -552,7 +552,7 @@ SCRIPT,
 
 		$apply_filters = apply_filters( 'script_loader_tag', '', 'my-script-with-closure-data' );
 		$this->assertEquals( <<< SCRIPT
-<script id="my-script-with-closure-data-js-extra">
+<script id='my-script-with-closure-data-js-extra'>
 var scriptWithClosureData = {"animal":"cat","color":"orange"};
 </script>
 <script id="my-script-with-closure-data-ns-extra">
@@ -587,9 +587,9 @@ SCRIPT,
 		ob_start();
 		do_action( 'test_action' );
 		$this->assertEquals( <<< SCRIPT
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script.js?ver=1.0.0" id="my-deps-base-script-js"></script>
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script.js?ver=1.0.0" id="my-deps-vendor-script-js"></script>
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script.js?ver=1.0.0" id="my-deps-dependent-script-js"></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script.js?ver=1.0.0' id='my-deps-base-script-js'></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script.js?ver=1.0.0' id='my-deps-vendor-script-js'></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script.js?ver=1.0.0' id='my-deps-dependent-script-js'></script>
 
 SCRIPT,
 			ob_get_clean()
@@ -625,9 +625,9 @@ SCRIPT,
 		ob_start();
 		do_action( 'test_action_2' );
 		$this->assertEquals( <<< SCRIPT
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script-2.js?ver=1.0.0" id="my-base-script-2-js"></script>
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script-2.js?ver=1.0.0" id="my-vendor-script-2-js"></script>
-<script src="http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script-2.js?ver=1.0.0" id="my-dependent-script-2-js"></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/base-script-2.js?ver=1.0.0' id='my-base-script-2-js'></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/vendor-script-2.js?ver=1.0.0' id='my-vendor-script-2-js'></script>
+<script src='http://wordpress.test/wp-content/plugins/assets/tests/_data/js/dependent-script-2.js?ver=1.0.0' id='my-dependent-script-2-js'></script>
 
 SCRIPT,
 			ob_get_clean()


### PR DESCRIPTION
When adding assets, an asset would be added to the `Assets::$assets` array with the slug as the index and with a numeric index. There's no reason for the numeric index, as it just causes extra looping and attempts to enqueue.

## Before:

```php
[
  'my-style'  => Asset /* my-style */,
  0           => Asset /* my-style */,
  'my-script' => Asset /* my-script */,
  1           => Asset /* my-script */,
]
```

## After

```php
[
  'my-style'  => Asset /* my-style */,
  'my-script' => Asset /* my-script */,
]
```