### PR TITLE
Ensure reigster_in_wp accepts only null or Asset or Asset[]

### DIFF
--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -678,8 +678,9 @@ class Assets {
 	 * Register the Assets on the correct hooks.
 	 *
 	 * @since 1.0.0
+	 * @since 1.4.5 Ensure the method accepts only `null` or an `Asset` instance or an array of `Asset[]` instances.
 	 *
-	 * @param array|Asset|null $assets Array of asset objects, single asset object, or null.
+	 * @param Asset[]|Asset|null $assets Array of asset objects, single asset object, or null.
 	 *
 	 * @return void
 	 */

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -2,6 +2,8 @@
 
 namespace StellarWP\Assets;
 
+use InvalidArgumentException;
+
 class Assets {
 	/**
 	 * @var ?Assets
@@ -693,15 +695,17 @@ class Assets {
 			}
 
 			if ( ! is_array( $assets ) ) {
-				if ( ! $assets instanceof Asset ) {
-					throw new \InvalidArgumentException( 'Assets in register_in_wp() must be of type Asset' );
-				}
-
-				$assets = [ $assets->get_slug() => $assets ];
+				$assets = [ $assets ];
 			}
 
-			// Register later, avoid the doing_it_wrong notice.
-			$this->assets = array_merge( $this->assets, $assets );
+			foreach ( $assets as $asset ) {
+				if ( ! $asset instanceof Asset ) {
+					throw new InvalidArgumentException( 'Assets in register_in_wp() must be of type Asset' );
+				}
+
+				// Register later, avoid the doing_it_wrong notice.
+				$this->assets[ $asset->get_slug() ] = $asset;
+			}
 
 			return;
 		}
@@ -715,6 +719,10 @@ class Assets {
 		}
 
 		foreach ( $assets as $asset ) {
+			if ( ! $asset instanceof Asset ) {
+				throw new InvalidArgumentException( 'Assets in register_in_wp() must be of type Asset' );
+			}
+
 			// Asset is already registered.
 			if ( $asset->is_registered() ) {
 				continue;

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -691,7 +691,7 @@ class Assets {
 		)
 		) {
 			// Registering the asset now would trigger a doing_it_wrong notice: queue the assets to be registered later.
-			if ( $assets === null ) {
+			if ( $assets === null || empty( $assets ) ) {
 				return;
 			}
 
@@ -711,12 +711,16 @@ class Assets {
 			return;
 		}
 
-		if ( is_null( $assets ) ) {
+		if ( null === $assets ) {
 			$assets = $this->get();
 		}
 
 		if ( ! is_array( $assets ) ) {
 			$assets = [ $assets ];
+		}
+
+		if ( empty( $assets ) ) {
+			return;
 		}
 
 		foreach ( $assets as $asset ) {

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -56,6 +56,9 @@ class AssetsTest extends AssetTestCase {
 
 		$assets = Assets::init();
 
+		$assets->register_in_wp( null ); // No problemo... nothing happens though.
+		$assets->register_in_wp( [] ); // No problemo... nothing happens though.
+
 		$this->assertFalse( $asset_1->is_registered() );
 		$assets->register_in_wp( $asset_1 );
 		$this->assertTrue( $asset_1->is_registered() );
@@ -77,9 +80,7 @@ class AssetsTest extends AssetTestCase {
 		yield 'float'          => [ fn() => 1.1 ];
 		yield 'bool - true'    => [ fn() => true ];
 		yield 'bool - false'   => [ fn() => false ];
-		yield 'null'           => [ fn() => null ];
 		yield 'object'         => [ fn() => new stdClass() ];
-		yield 'array'          => [ fn() => [] ];
 		yield 'array - mixed'  => [ fn () => [ Asset::add( 'fake1-script', 'fake1.js' ), 'string' ] ];
 	}
 

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -91,7 +91,7 @@ class AssetsTest extends AssetTestCase {
 		$assets = Assets::init();
 
 		$this->expectException( InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'Invalid parameter passed to register_in_wp' );
+		$this->expectExceptionMessage( 'Assets in register_in_wp() must be of type Asset' );
 
 		$assets->register_in_wp( $fixture() );
 	}


### PR DESCRIPTION
Builds on top of #31.

Covers one more case as mentioned [here](https://github.com/stellarwp/assets/pull/31#discussion_r1922389051).

Covers the changes with tests.