### PR TITLE
Add new filter to asset version

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1128,8 +1128,6 @@ class Asset {
 		/**
 		 * Filters the asset version when it doesn't come from an asset file.
 		 *
-		 * @since TBD
-		 *
 		 * @param string $version The asset version.
 		 * @param string $slug    The asset slug.
 		 * @param Asset  $asset   The Asset object.

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1123,6 +1123,8 @@ class Asset {
 			return (string) $asset_file_contents['version'];
 		}
 
+		$hook_prefix = Config::get_hook_prefix();
+
 		/**
 		 * Filters the asset version when it doesn't come from an asset file.
 		 *
@@ -1132,7 +1134,7 @@ class Asset {
 		 * @param string $slug    The asset slug.
 		 * @param Asset  $asset   The Asset object.
 		 */
-		return (string) apply_filters( 'stellarwp/assets/asset/version', $this->version, $this->slug, $this );
+		return (string) apply_filters( "stellarwp/assets/{$hook_prefix}/version", $this->version, $this->slug, $this );
 	}
 
 	/**

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1123,7 +1123,16 @@ class Asset {
 			return (string) $asset_file_contents['version'];
 		}
 
-		return $this->version;
+		/**
+		 * Filters the asset version when it doesn't come from an asset file.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $version The asset version.
+		 * @param string $slug    The asset slug.
+		 * @param Asset  $asset   The Asset object.
+		 */
+		return (string) apply_filters( 'stellarwp/assets/asset/version', $this->version, $this->slug, $this );
 	}
 
 	/**

--- a/tests/wpunit/AssetTest.php
+++ b/tests/wpunit/AssetTest.php
@@ -29,4 +29,31 @@ class AssetTest extends AssetTestCase {
 
 		$this->assertEquals( WP_PLUGIN_DIR . '/assets/tests/_data/', $asset->get_root_path() );
 	}
+
+	public function test_can_filter_asset_version(): void {
+		$prefix = 'bork';
+
+		Config::reset();
+		Config::set_hook_prefix( $prefix );
+		Config::set_version( '1.1.0' );
+		Config::set_path( constant( 'WP_PLUGIN_DIR' ) . '/assets' );
+
+		$asset = new Asset( 'test-script', 'fake.js', '1.0.0', codecept_data_dir() );
+
+		// The asset version should be the same as the one passed to the constructor.
+		$this->assertEquals( '1.0.0', $asset->get_version() );
+
+		// Filter the asset version.
+		$filter = function () {
+			return '2.0.0';
+		};
+
+		add_filter( "stellarwp/assets/{$prefix}/version", $filter );
+
+		// After filtering, the asset version should be updated.
+		$this->assertEquals( '2.0.0', $asset->get_version() );
+
+		// Cleanup the filter.
+		remove_filter( "stellarwp/assets/{$prefix}/version", $filter );
+	}
 }


### PR DESCRIPTION
This PR adds a new filter: `stellarwp/assets/{$hook_prefix}/version`. This allows filtering the asset version string when it does *not* come from an asset file.

This is particularly useful in development when the asset file has changes but the `$version` value used when registering the asset hasn't changed. E.g. for an asset `jpry-cool-asset`, I could filter the version to something like `time()` in this way:

```php
$prefix = 'jpry';

add_filter(
	"stellarwp/assets/{$prefix}/version",
	function ( $version, $slug ) {
		return 'jpry-cool-asset' === $slug
			? time()
			: $version;
	},
	10,
	2
);
```
