### PR TITLE
performance: Only apply enqueue filters if needed

### DIFF
--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -628,7 +628,7 @@ class Assets {
 		 * @since 1.0.0
 		 *
 		 */
-		$enqueue = (bool) apply_filters( "stellarwp/assets/{$hook_prefix}/enqueue", $enqueue, $asset );
+		$enqueue = $enqueue && (bool) apply_filters( "stellarwp/assets/{$hook_prefix}/enqueue", $enqueue, $asset );
 
 		/**
 		 * Allows developers to hook-in and prevent an asset from being loaded.
@@ -639,7 +639,7 @@ class Assets {
 		 * @since 1.0.0
 		 *
 		 */
-		$enqueue = (bool) apply_filters( "stellarwp/assets/{$hook_prefix}/enqueue_{$slug}", $enqueue, $asset );
+		$enqueue = $enqueue && (bool) apply_filters( "stellarwp/assets/{$hook_prefix}/enqueue_{$slug}", $enqueue, $asset );
 
 		if ( ! $enqueue && ! $force_enqueue ) {
 			return;


### PR DESCRIPTION
If the asset's condition for enqueue has already failed, do not waste time applying filters. As documented, those additional filters will only add more failure conditions, not fewer.