### PR TITLE
fixed a rare case where assets urls are created invalid

### DIFF
--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -136,7 +136,8 @@ class Config {
 
 		if ( empty( static::$path_urls[ $key ] ) ) {
 			$bases = Utils::get_bases();
-			static::$path_urls[ $key ] = trailingslashit( str_replace( wp_list_pluck( $bases, 'base_dir' ), wp_list_pluck( $bases, 'base_url' ), $path ) );
+			static::$path_urls[ $key ] = trailingslashit( strtr($path, array_combine(wp_list_pluck( $bases, 'base_dir' ), wp_list_pluck( $bases, 'base_url' ) ) ) );
+
 		}
 
 		return static::$path_urls[ $key ];


### PR DESCRIPTION
Hi,
we found an rare case in which library return an invalid url. 
some preconditions:
- php engine jail in chrooted mode ( or DocumentRoot is in root filesystem). 
- base root have the same name of domain
which this condition in file Config.php on method get_url the function str_replace trigger the transformation many time for the string.
this is te our test env

wp_list_pluck( $bases, 'base_dir' ) return
```
Array
(
    [wpmu_plugin] => /miodominiouno.it/ita/wp-content/mu-plugins
    [wp_plugin] => /miodominiouno.it/ita/wp-content/plugins
    [wp_content] => /miodominiouno.it/ita/wp-content
    [plugins] => /miodominiouno.it/ita/wp-content/plugins
    [stylesheet] => /miodominiouno.it/ita/wp-content/themes/twentytwentyfive
))
```

wp_list_pluck( $bases, 'base_url' ) return
```
Array
(
    [wpmu_plugin] => http://miodominiouno.it/ita/wp-content/mu-plugins
    [wp_plugin] => http://miodominiouno.it/ita/wp-content/plugins
    [wp_content] => http://miodominiouno.it/ita/wp-content
    [plugins] => http://miodominiouno.it/ita/wp-content/plugins
    [stylesheet] => http://miodominiouno.it/ita/wp-content/themes/twentytwentyfive
)
```

the transformation return 
```http:/http:/http://miodominiouno.it/ita/wp-content/plugins/the-events-calendar/common/```

we have made a test using strtr that perform only one substitution and the code works.

We attach a 1 line patch