### PR TITLE
Since dependencies must be arrays, ensure they are if not a callable.

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.4
+ * Version: 1.4.8
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -878,7 +878,7 @@ class Asset {
 			);
 		}
 
-		return $dependencies;
+		return (array) $dependencies;
 	}
 
 	/**
@@ -1791,7 +1791,7 @@ class Asset {
 		if ( $dependencies[0] && is_callable( $dependencies[0] ) ) {
 			$this->dependencies = $dependencies[0];
 		} else {
-			$this->dependencies = $dependencies;
+			$this->dependencies = (array) $dependencies;
 		}
 
 		return $this;


### PR DESCRIPTION
In set_dependencies, if the first argument is not a callable, cast it to an array when we assign it to the class property.

In get_dependencies, cast the return value to an array.

Issue: https://github.com/stellarwp/assets/issues/37