### PR TITLE
Add a dedicated Vendor Asset class

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -78,28 +78,28 @@ class Asset {
 	protected array $groups = [];
 
 	/**
-	 * Should the asset be loaded in the footer?
+	 * Whether the asset be loaded in the footer.
 	 *
 	 * @var bool
 	 */
 	protected bool $in_footer = true;
 
 	/**
-	 * Should the asset be marked as async?
+	 * Whether the asset be marked as async.
 	 *
 	 * @var bool
 	 */
 	protected bool $is_async = false;
 
 	/**
-	 * Should the asset be marked as deferred?
+	 * Whether the asset be marked as deferred.
 	 *
 	 * @var bool
 	 */
 	protected bool $is_deferred = false;
 
 	/**
-	 * Is the asset enqueued?
+	 * Whether the asset has been enqueued.
 	 *
 	 * @var bool
 	 */
@@ -113,21 +113,21 @@ class Asset {
 	protected bool $is_module = false;
 
 	/**
-	 * Is the asset printed?
+	 * Whether the asset has been printed.
 	 *
 	 * @var bool
 	 */
 	protected bool $is_printed = false;
 
 	/**
-	 * Is the asset registered?
+	 * Whether the asset has been registered.
 	 *
 	 * @var bool
 	 */
 	protected bool $is_registered = false;
 
 	/**
-	 * Is the asset a vendor asset?
+	 * Whether this is a vendor asset.
 	 *
 	 * @var bool
 	 */
@@ -534,7 +534,7 @@ class Asset {
 		$url = $plugin_base_url . $resource_path . $resource;
 
 		/**
-		 * Filters the asset URL
+		 * Filters the asset URL.
 		 *
 		 * @param string $url   Asset URL.
 		 * @param string $slug  Asset slug.

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -344,6 +344,8 @@ class Asset {
 	 * @param string      $file      The asset file path.
 	 * @param string|null $version   The asset version.
 	 * @param string|null $root_path The path to the root of the plugin.
+	 *
+	 * @return self
 	 */
 	public static function add( string $slug, string $file, string $version = null, $root_path = null ) {
 		return Assets::init()->add( new self( $slug, $file, $version, $root_path ) );

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -345,7 +345,7 @@ class Asset {
 	 * @param string|null $version   The asset version.
 	 * @param string|null $root_path The path to the root of the plugin.
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function add( string $slug, string $file, string $version = null, $root_path = null ) {
 		return Assets::init()->add( new self( $slug, $file, $version, $root_path ) );

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -345,7 +345,7 @@ class Asset {
 	 * @param string|null $version   The asset version.
 	 * @param string|null $root_path The path to the root of the plugin.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public static function add( string $slug, string $file, string $version = null, $root_path = null ) {
 		return Assets::init()->add( new self( $slug, $file, $version, $root_path ) );

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -78,21 +78,21 @@ class Asset {
 	protected array $groups = [];
 
 	/**
-	 * Whether the asset be loaded in the footer.
+	 * Whether the asset should be loaded in the footer.
 	 *
 	 * @var bool
 	 */
 	protected bool $in_footer = true;
 
 	/**
-	 * Whether the asset be marked as async.
+	 * Whether the asset should be marked as async.
 	 *
 	 * @var bool
 	 */
 	protected bool $is_async = false;
 
 	/**
-	 * Whether the asset be marked as deferred.
+	 * Whether the asset should be marked as deferred.
 	 *
 	 * @var bool
 	 */

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -681,11 +681,11 @@ class Asset {
 		$source_type = $this->get_type();
 
 		if ( $clone_type === $source_type ) {
-			throw new \InvalidArgumentException( 'The clone type must be different from the source type.' );
+			throw new InvalidArgumentException( 'The clone type must be different from the source type.' );
 		}
 
 		if ( ! in_array( $clone_type, [ 'css', 'js' ], true ) ) {
-			throw new \InvalidArgumentException( 'The clone type must be either "css" or "js".' );
+			throw new InvalidArgumentException( 'The clone type must be either "css" or "js".' );
 		}
 
 		$slug  = $this->slug;

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -114,17 +114,16 @@ class Assets {
 	 *
 	 */
 	public function add( Asset $asset ) {
-		// Prevent weird stuff here.
+		// Check if the slug is registered, and if so return the previously-registerd Asset.
 		$slug = $asset->get_slug();
 
 		if ( $this->exists( $slug ) ) {
 			return $this->get( $slug );
 		}
 
-		// Set the Asset on the array of notices.
+		// Add the asset to the array of assets.
 		$this->assets[ $slug ] = $asset;
 
-		// Return the Slug because it might be modified.
 		return $asset;
 	}
 

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -109,7 +109,7 @@ class Assets {
 	 *
 	 * @param Asset $asset Register an asset.
 	 *
-	 * @return Asset|false The registered object or false on error.
+	 * @return Asset|VendorAsset The registered object or false on error.
 	 * @since 1.0.0
 	 *
 	 */
@@ -192,7 +192,7 @@ class Assets {
 	 * @param string|array $slug Slug of the Asset.
 	 * @param boolean $sort If we should do any sorting before returning.
 	 *
-	 * @return array|Asset Array of asset objects, single asset object, or null if looking for a single asset but
+	 * @return array|Asset|VendorAsset Array of asset objects, single asset object, or null if looking for a single asset but
 	 *                           it was not in the array of objects.
 	 * @since 1.0.0
 	 *

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -109,12 +109,12 @@ class Assets {
 	 *
 	 * @param Asset $asset Register an asset.
 	 *
-	 * @return Asset|VendorAsset The registered object or false on error.
+	 * @return Asset|VendorAsset The registered object.
 	 * @since 1.0.0
 	 *
 	 */
 	public function add( Asset $asset ) {
-		// Check if the slug is registered, and if so return the previously-registerd Asset.
+		// Check if the slug is registered, and if so return the previously-registered Asset.
 		$slug = $asset->get_slug();
 
 		if ( $this->exists( $slug ) ) {

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -1,0 +1,129 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace StellarWP\Assets;
+
+use InvalidArgumentException;
+use LogicException;
+
+class VendorAsset extends Asset {
+
+	/**
+	 * Whether this is a vendor asset.
+	 *
+	 * @var bool
+	 */
+	protected bool $is_vendor = true;
+
+	/**
+	 * VendorAsset constructor.
+	 *
+	 * @param string $slug The asset slug.
+	 * @param string $url  The asset URL.
+	 * @param string $type The asset type.
+	 *
+	 * @throws InvalidArgumentException If the URL is not valid.
+	 */
+	public function __construct( string $slug, string $url, string $type = 'js' ) {
+		$filtered = filter_var( $url, FILTER_VALIDATE_URL );
+		if ( false === $filtered ) {
+			throw new InvalidArgumentException( 'The URL must be a valid URL.' );
+		}
+
+		$this->url  = $filtered;
+		$this->slug = sanitize_key( $slug );
+		$this->type = strtolower( $type );
+	}
+
+	/**
+	 * Set the asset version.
+	 *
+	 * @param string $version The asset version.
+	 *
+	 * @return $this
+	 */
+	public function set_version( string $version ): self {
+		$this->version = $version;
+		return $this;
+	}
+
+	/**
+	 * Get the asset version.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string The asset version.
+	 */
+	public function get_version(): string {
+		return $this->version ?? '';
+	}
+
+	/**
+	 * Get the asset url.
+	 *
+	 * If the version has been provided, then it will be used to format the URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $use_min_if_available (Unused) Use the minified version of the asset if available.
+	 *
+	 * @return string
+	 * @throws LogicException If the URL has a placeholder but no version is provided.
+	 */
+	public function get_url( bool $use_min_if_available = true ): string {
+		$has_version = null !== $this->version;
+		if ( ! $has_version && $this->url_has_placeholder( $this->url ) ) {
+			throw new LogicException( 'A URL with a placeholder must have a version provided.' );
+		}
+
+		$url = $has_version
+			? $this->get_formatted_url()
+			: $this->url;
+
+		$hook_prefix = Config::get_hook_prefix();
+
+		/**
+		 * Filters the asset URL.
+		 *
+		 * @param string $url   Asset URL.
+		 * @param string $slug  Asset slug.
+		 * @param Asset  $asset The Asset object.
+		 */
+		return (string) apply_filters( "stellarwp/assets/{$hook_prefix}/resource_url", $url, $this->slug, $this );
+	}
+
+	/**
+	 * Get the minified version of the URL.
+	 *
+	 * @return string
+	 */
+	public function get_min_url(): string {
+		return $this->get_url();
+	}
+
+	/**
+	 * Get the formatted version of the URL.
+	 *
+	 * This will replace the version placeholder in the URL with the actual version. If there
+	 * is no placeholder, it will append the version as a query string.
+	 *
+	 * @return string
+	 */
+	protected function get_formatted_url() {
+		return $this->url_has_placeholder( $this->url )
+			? sprintf( $this->url, $this->version )
+			: add_query_arg( 'ver', $this->version, $this->url );
+	}
+
+	/**
+	 * Determine if the URL has a placeholder for the version.
+	 *
+	 * @param string $url The URL to check.
+	 *
+	 * @return bool True if the URL has a placeholder, false otherwise.
+	 */
+	protected function url_has_placeholder( string $url ): bool {
+		return false !== strpos( $url, '%s' );
+	}
+}

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -74,7 +74,7 @@ class VendorAsset extends Asset {
 	 *
 	 * @param string $version The asset version.
 	 *
-	 * @return $this
+	 * @return static
 	 */
 	public function set_version( string $version ): self {
 		$this->version = $version;
@@ -138,8 +138,8 @@ class VendorAsset extends Asset {
 	/**
 	 * Get the formatted version of the URL.
 	 *
-	 * This will replace the version placeholder in the URL with the actual version. If there
-	 * is no placeholder, it will append the version as a query string.
+	 * This will replace the version placeholder in the URL with the actual version.
+	 * If there is no placeholder, it will append the version as a query string.
 	 *
 	 * @return string
 	 */
@@ -246,7 +246,7 @@ class VendorAsset extends Asset {
 	 * @param ?string $path   The path to the minified file.
 	 * @param ?bool   $prefix Whether to prefix files automatically by type (e.g. js/ for JS). Defaults to true.
 	 *
-	 * @return $this
+	 * @return static
 	 */
 	public function set_path( ?string $path = null, $prefix = null ) {
 		return $this;
@@ -257,7 +257,7 @@ class VendorAsset extends Asset {
 	 *
 	 * @param ?string $path The path to the minified file.
 	 *
-	 * @return $this
+	 * @return static
 	 */
 	public function set_min_path( ?string $path = null ) {
 		return $this;
@@ -268,7 +268,7 @@ class VendorAsset extends Asset {
 	 *
 	 * @param boolean $_unused Whether to use an .asset.php file.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public function use_asset_file( bool $_unused = true ): self {
 		return $this;

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -44,6 +44,24 @@ class VendorAsset extends Asset {
 	}
 
 	/**
+	 * Registers a vendor asset.
+	 *
+	 * @param string  $slug    The asset slug.
+	 * @param string  $url     The asset file path.
+	 * @param ?string $type    The asset type.
+	 * @param ?string $version The asset version.
+	 */
+	public static function add( string $slug, string $url, ?string $type = null, ?string $version = null ) {
+		$instance = new self( $slug, $url, $type ?? 'js' );
+
+		if ( null !== $version ) {
+			$instance->set_version( $version );
+		}
+
+		return Assets::init()->add( $instance );
+	}
+
+	/**
 	 * Set the asset version.
 	 *
 	 * @param string $version The asset version.

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -51,11 +51,11 @@ class VendorAsset extends Asset {
 	 * @param ?string $type    The asset type.
 	 * @param ?string $version The asset version.
 	 */
-	public static function add( string $slug, string $url, ?string $type = null, ?string $version = null ) {
+	public static function add( string $slug, string $url, ?string $type = null, $version = null ) {
 		$instance = new self( $slug, $url, $type ?? 'js' );
 
 		if ( null !== $version ) {
-			$instance->set_version( $version );
+			$instance->set_version( (string) $version );
 		}
 
 		return Assets::init()->add( $instance );

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -17,6 +17,13 @@ class VendorAsset extends Asset {
 	protected bool $is_vendor = true;
 
 	/**
+	 * Whether to attempt to load an .asset.php file.
+	 *
+	 * @var bool
+	 */
+	protected bool $use_asset_file = false;
+
+	/**
 	 * VendorAsset constructor.
 	 *
 	 * @param string $slug The asset slug.
@@ -137,6 +144,15 @@ class VendorAsset extends Asset {
 	 * @return string
 	 */
 	public function get_asset_file_path(): string {
+		return '';
+	}
+
+	/**
+	 * Get the asset file.
+	 *
+	 * @return string
+	 */
+	public function get_file(): string {
 		return '';
 	}
 

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -6,6 +6,7 @@ namespace StellarWP\Assets;
 
 use InvalidArgumentException;
 use LogicException;
+use RuntimeException;
 
 class VendorAsset extends Asset {
 
@@ -51,7 +52,7 @@ class VendorAsset extends Asset {
 	 * @param ?string $type    The asset type.
 	 * @param ?string $version The asset version.
 	 *
-	 * @return static
+	 * @return self
 	 */
 	public static function add( string $slug, string $url, ?string $type = null, $version = null ) {
 		$instance = new self( $slug, $url, $type ?? 'js' );
@@ -60,7 +61,12 @@ class VendorAsset extends Asset {
 			$instance->set_version( (string) $version );
 		}
 
-		return Assets::init()->add( $instance );
+		$registered = Assets::init()->add( $instance );
+		if ( ! $registered instanceof self ) {
+			throw new RuntimeException( 'The asset was already registered as a different type.' );
+		}
+
+		return $registered;
 	}
 
 	/**

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -50,6 +50,8 @@ class VendorAsset extends Asset {
 	 * @param string  $url     The asset file path.
 	 * @param ?string $type    The asset type.
 	 * @param ?string $version The asset version.
+	 *
+	 * @return self
 	 */
 	public static function add( string $slug, string $url, ?string $type = null, $version = null ) {
 		$instance = new self( $slug, $url, $type ?? 'js' );

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -66,12 +66,12 @@ class VendorAsset extends Asset {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param bool $use_min_if_available (Unused) Use the minified version of the asset if available.
+	 * @param bool $_unused (Unused) Use the minified version of the asset if available.
 	 *
 	 * @return string
 	 * @throws LogicException If the URL has a placeholder but no version is provided.
 	 */
-	public function get_url( bool $use_min_if_available = true ): string {
+	public function get_url( bool $_unused = true ): string {
 		$has_version = null !== $this->version;
 		if ( ! $has_version && $this->url_has_placeholder( $this->url ) ) {
 			throw new LogicException( 'A URL with a placeholder must have a version provided.' );
@@ -125,5 +125,110 @@ class VendorAsset extends Asset {
 	 */
 	protected function url_has_placeholder( string $url ): bool {
 		return false !== strpos( $url, '%s' );
+	}
+
+	// ---------------------------------------------
+	// NO-OP or UNUSED METHODS
+	// ---------------------------------------------
+
+	/**
+	 * Get the asset asset file path.
+	 *
+	 * @return string
+	 */
+	public function get_asset_file_path(): string {
+		return '';
+	}
+
+	/**
+	 * Get the asset min path.
+	 *
+	 * @return string
+	 */
+	public function get_min_path(): string {
+		return '';
+	}
+
+	/**
+	 * Get the asset min path.
+	 *
+	 * @return string
+	 */
+	public function get_path(): string {
+		return '';
+	}
+
+	/**
+	 * Gets the root path for the resource.
+	 *
+	 * @return ?string
+	 */
+	public function get_root_path(): ?string {
+		return '';
+	}
+
+	/**
+	 * Get the asset translation path.
+	 *
+	 * @return string
+	 */
+	public function get_translation_path(): string {
+		return '';
+	}
+
+	/**
+	 * Get the asset's full path - considering if minified exists.
+	 *
+	 * @param bool $_unused
+	 *
+	 * @return string
+	 */
+	public function get_full_resource_path( bool $_unused = true ): string {
+		return $this->get_url( $_unused );
+	}
+
+	/**
+	 * Set the asset file path for the asset.
+	 *
+	 * @param string $path The partial path to the asset.
+	 *
+	 * @return static
+	 */
+	public function set_asset_file( string $path ) {
+		return $this;
+	}
+
+	/**
+	 * Set the directory where asset should be retrieved.
+	 *
+	 * @param ?string $path   The path to the minified file.
+	 * @param ?bool   $prefix Whether to prefix files automatically by type (e.g. js/ for JS). Defaults to true.
+	 *
+	 * @return $this
+	 */
+	public function set_path( ?string $path = null, $prefix = null ) {
+		return $this;
+	}
+
+	/**
+	 * Set the directory where min files should be retrieved.
+	 *
+	 * @param ?string $path The path to the minified file.
+	 *
+	 * @return $this
+	 */
+	public function set_min_path( ?string $path = null ) {
+		return $this;
+	}
+
+	/**
+	 * Set whether or not to use an .asset.php file.
+	 *
+	 * @param boolean $_unused Whether to use an .asset.php file.
+	 *
+	 * @return self
+	 */
+	public function use_asset_file( bool $_unused = true ): self {
+		return $this;
 	}
 }

--- a/src/Assets/VendorAsset.php
+++ b/src/Assets/VendorAsset.php
@@ -51,7 +51,7 @@ class VendorAsset extends Asset {
 	 * @param ?string $type    The asset type.
 	 * @param ?string $version The asset version.
 	 *
-	 * @return self
+	 * @return static
 	 */
 	public static function add( string $slug, string $url, ?string $type = null, $version = null ) {
 		$instance = new self( $slug, $url, $type ?? 'js' );

--- a/tests/wpunit/VendorAssetTest.php
+++ b/tests/wpunit/VendorAssetTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace wpunit;
+
+use InvalidArgumentException;
+use LogicException;
+use StellarWP\Assets\Config;
+use StellarWP\Assets\Tests\AssetTestCase;
+use StellarWP\Assets\VendorAsset;
+
+class VendorAssetTest extends AssetTestCase {
+
+	/**
+	 * @before
+	 */
+	public function before_tests(): void {
+		Config::reset();
+		Config::set_hook_prefix( 'jpry' );
+	}
+
+	public function test_can_create_vendor_asset(): void {
+		$asset = new VendorAsset( 'test-script', 'https://example.com/fake.js' );
+
+		$this->assertEquals( 'test-script', $asset->get_slug() );
+		$this->assertEquals( 'https://example.com/fake.js', $asset->get_url() );
+		$this->assertEquals( 'js', $asset->get_type() );
+	}
+
+	public function test_invalid_url_throws_exception(): void {
+		$this->expectException( InvalidArgumentException::class );
+
+		new VendorAsset( 'test-script', 'invalid-url' );
+	}
+
+	public function test_can_set_version(): void {
+		$asset = new VendorAsset( 'test-script', 'https://example.com/fake.js' );
+		$asset->set_version( '1.0.0' );
+
+		$this->assertEquals( '1.0.0', $asset->get_version() );
+		$this->assertEquals( 'https://example.com/fake.js?ver=1.0.0', $asset->get_url() );
+	}
+
+	public function test_can_set_version_with_url_placeholder(): void {
+		$asset = new VendorAsset( 'test-script', 'https://example.com/path/to/version/%s/fake.js' );
+		$asset->set_version( '1.2.3' );
+		$this->assertEquals( '1.2.3', $asset->get_version() );
+		$this->assertEquals( 'https://example.com/path/to/version/1.2.3/fake.js', $asset->get_url() );
+	}
+
+	public function test_placeholder_without_version_throws_error(): void {
+		$this->expectException( LogicException::class );
+		$this->expectExceptionMessage( 'A URL with a placeholder must have a version provided.' );
+
+		$asset = new VendorAsset( 'test-script', 'https://example.com/path/to/version/%s/fake.js' );
+		$asset->get_url();
+	}
+
+	public function test_version_with_query_string_has_ver_appended_correctly(): void {
+		$asset = new VendorAsset( 'test-script', 'https://example.com/path/to/version?query=string' );
+		$asset->set_version( '1.2.3' );
+
+		$this->assertEquals( '1.2.3', $asset->get_version() );
+		$this->assertEquals( 'https://example.com/path/to/version?query=string&ver=1.2.3', $asset->get_url() );
+	}
+}


### PR DESCRIPTION
This adds the `VendorAsset` class for use with vendor scripts. The specific uses case is when handling a 3rd-party asset and registering a CDN URL for the asset instead of a local URL.

Notable changes:

1. Creates the `VendorAsset` class as an extension of the `Asset` class.
1. Adds a `wpunit` test suite to test various aspects of `VendorAsset`.
1. Makes some minor tweaks to docblocks in the main `Asset` class.

