### PR TITLE
Prevents enqueueing assets when an empty array is provided

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.10
+ * Version: 1.4.11
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -537,11 +537,11 @@ class Assets {
 	 * useful where an asset is required in a situation not anticipated when it was originally
 	 * registered.
 	 *
-	 * @param string|array $assets_to_enqueue Which assets will be enqueued.
-	 * @param bool $should_enqueue_no_matter_what Whether to ignore conditional requirements when enqueuing.
+	 * @param string|array $assets_to_enqueue             Which assets will be enqueued.
+	 * @param bool         $should_enqueue_no_matter_what Whether to ignore conditional requirements when enqueuing.
 	 *
 	 * @since 1.0.0
-	 * @since TBD - If explicitly passed an empty array, enqueue nothing.
+	 * @since 1.4.11 - If explicitly passed an empty array, enqueue nothing.
 	 */
 	public function enqueue( $assets_to_enqueue = null, bool $should_enqueue_no_matter_what = false ) {
 		// If explicitly passed an empty array, enqueue nothing.

--- a/src/Assets/Assets.php
+++ b/src/Assets/Assets.php
@@ -541,9 +541,14 @@ class Assets {
 	 * @param bool $should_enqueue_no_matter_what Whether to ignore conditional requirements when enqueuing.
 	 *
 	 * @since 1.0.0
-	 *
+	 * @since TBD - If explicitly passed an empty array, enqueue nothing.
 	 */
 	public function enqueue( $assets_to_enqueue = null, bool $should_enqueue_no_matter_what = false ) {
+		// If explicitly passed an empty array, enqueue nothing.
+		if ( is_array( $assets_to_enqueue ) && empty( $assets_to_enqueue ) ) {
+			return;
+		}
+
 		$assets_to_enqueue = array_filter( (array) $assets_to_enqueue );
 		if ( ! empty( $assets_to_enqueue ) ) {
 			$assets = (array) $this->get( $assets_to_enqueue );

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -1095,6 +1095,36 @@ SCRIPT,
 	}
 
 	/**
+	 * It should not enqueue any assets when an empty group is requested
+	 *
+	 * @test
+	 */
+	public function should_not_enqueue_any_assets_when_empty_group_is_requested(): void {
+		// Register multiple assets WITHOUT enqueue_on actions
+		// (we don't want them to auto-enqueue, we only want to test group enqueueing)
+		Asset::add( 'test-script-no-group-1', 'test-script-1.js' )
+			->register();
+		Asset::add( 'test-script-no-group-2', 'test-script-2.js' )
+			->register();
+		Asset::add( 'test-style-no-group', 'test-style.css' )
+			->register();
+
+		// Register assets with groups
+		Asset::add( 'test-script-with-group', 'test-script-with-group.js' )
+			->add_to_group( 'existing-group' )
+			->register();
+
+		// Call enqueue_group with a non-existent group (should enqueue nothing)
+		Assets::init()->enqueue_group( 'non-existent-group' );
+
+		// Verify that no assets were enqueued
+		$this->assertFalse( wp_script_is( 'test-script-no-group-1', 'enqueued' ), 'Script without group 1 should not be enqueued' );
+		$this->assertFalse( wp_script_is( 'test-script-no-group-2', 'enqueued' ), 'Script without group 2 should not be enqueued' );
+		$this->assertFalse( wp_style_is( 'test-style-no-group', 'enqueued' ), 'Style without group should not be enqueued' );
+		$this->assertFalse( wp_script_is( 'test-script-with-group', 'enqueued' ), 'Script with different group should not be enqueued' );
+	}
+
+	/**
 	 * Set a constant value using uopz.
 	 *
 	 * @param string $const


### PR DESCRIPTION
Adds a check in the `enqueue` method to prevent any asset enqueueing
when an empty array is explicitly passed. This ensures the method
behaves as expected in such scenarios.

Also adds a test to verify that no assets are enqueued when a
non-existent group is requested via `enqueue_group`.
