### PR TITLE
Fix/path to url replacement

### DIFF
--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.11
+ * Version: 1.4.12
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/assets.php
+++ b/assets.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Assets
  * Description: Asset library with a plugin bootstrap file for automated testing.
- * Version: 1.4.12
+ * Version: 1.5.1
  * Author: StellarWP
  * Author URI: https://stellarwp.com
  */

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -136,7 +136,8 @@ class Config {
 
 		if ( empty( static::$path_urls[ $key ] ) ) {
 			$bases = Utils::get_bases();
-			static::$path_urls[ $key ] = trailingslashit( str_replace( wp_list_pluck( $bases, 'base_dir' ), wp_list_pluck( $bases, 'base_url' ), $path ) );
+			static::$path_urls[ $key ] = trailingslashit( strtr($path, array_combine(wp_list_pluck( $bases, 'base_dir' ), wp_list_pluck( $bases, 'base_url' ) ) ) );
+
 		}
 
 		return static::$path_urls[ $key ];

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -148,6 +148,8 @@ class Config {
 	/**
 	 * Gets the root path of the project.
 	 *
+	 * @since 1.4.12
+	 *
 	 * @return string
 	 */
 	public static function get_url( $path ): string {
@@ -156,16 +158,25 @@ class Config {
 
 		if ( empty( static::$path_urls[ $key ] ) ) {
 			$bases = Utils::get_bases();
-			static::$path_urls[ $key ] = trailingslashit(
-				strtr(
-					$path,
-					array_combine(
-						wp_list_pluck( $bases, 'base_dir' ),
-						wp_list_pluck( $bases, 'base_url' )
-					)
-				)
-			);
 
+			$base_dirs = wp_list_pluck( $bases, 'base_dir' );
+			$base_urls = wp_list_pluck( $bases, 'base_url' );
+
+			uasort( $base_dirs, function( $a, $b ) {
+				return strlen( $b ) <=> strlen( $a );
+			} );
+
+			foreach ( $base_dirs as $dir_type => $dir_path ) {
+				if ( ! isset( $base_urls[ $dir_type ] ) ) {
+					continue;
+				}
+
+				static::$path_urls[ $key ] = str_replace( $dir_path, $base_urls[ $dir_type ], $path );
+
+				if ( static::$path_urls[ $key ] !== $path ) {
+					break;
+				}
+			}
 		}
 
 		return static::$path_urls[ $key ];

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -148,7 +148,7 @@ class Config {
 	/**
 	 * Gets the root path of the project.
 	 *
-	 * @since 1.4.12
+	 * @since 1.5.1
 	 *
 	 * @return string
 	 */

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -156,7 +156,15 @@ class Config {
 
 		if ( empty( static::$path_urls[ $key ] ) ) {
 			$bases = Utils::get_bases();
-			static::$path_urls[ $key ] = trailingslashit( strtr($path, array_combine(wp_list_pluck( $bases, 'base_dir' ), wp_list_pluck( $bases, 'base_url' ) ) ) );
+			static::$path_urls[ $key ] = trailingslashit(
+				strtr(
+					$path,
+					array_combine(
+						wp_list_pluck( $bases, 'base_dir' ),
+						wp_list_pluck( $bases, 'base_url' )
+					)
+				)
+			);
 
 		}
 

--- a/src/Assets/Config.php
+++ b/src/Assets/Config.php
@@ -159,8 +159,8 @@ class Config {
 		if ( empty( static::$path_urls[ $key ] ) ) {
 			$bases = Utils::get_bases();
 
-			$base_dirs = wp_list_pluck( $bases, 'base_dir' );
-			$base_urls = wp_list_pluck( $bases, 'base_url' );
+			$base_dirs = array_column( $bases, 'base_dir' );
+			$base_urls = array_column( $bases, 'base_url' );
 
 			uasort( $base_dirs, function( $a, $b ) {
 				return strlen( $b ) <=> strlen( $a );

--- a/tests/wpunit/AssetsTest.php
+++ b/tests/wpunit/AssetsTest.php
@@ -464,6 +464,16 @@ class AssetsTest extends AssetTestCase {
 					'WP_PLUGIN_URL'  => 'http://wordpress.test/wp-content/addons',
 				],
 			],
+			[
+				'rare case',
+				[
+					'ABSPATH' => '/wordpress.test/',
+					'WP_CONTENT_DIR' => '/wordpress.test/wp-content',
+					'WP_CONTENT_URL' => 'http://wordpress.test/wp-content',
+					'WP_PLUGIN_DIR' => '/wordpress.test/wp-content/plugins',
+					'WP_PLUGIN_URL' => 'http://wordpress.test/wp-content/plugins',
+				],
+			],
 		];
 
 		foreach ( $data as $d ) {
@@ -1129,7 +1139,7 @@ SCRIPT,
 
 		$plugins_path = str_replace( constant( 'WP_CONTENT_DIR' ), '', constant( 'WP_PLUGIN_DIR' ) );
 
-		if ( constant( 'WP_PLUGIN_DIR' ) !== constant( 'WP_CONTENT_DIR' ) . $plugins_path || strpos( constant( 'ABSPATH' ), 'C:') === 0 || $wont_figure_out_min_vs_unmin ) {
+		if ( constant( 'WP_PLUGIN_DIR' ) !== constant( 'WP_CONTENT_DIR' ) . $plugins_path || strpos( constant( 'ABSPATH' ), 'C:') === 0 || strpos( constant( 'ABSPATH' ), '/wordpress.test/') === 0 || $wont_figure_out_min_vs_unmin ) {
 			// If we are testing outside of the actual plugin directory, the `is_file` check will always fail.
 			// In installations where this set up is the actual, the file should exist.
 			// In this case it will always fail to locate mins.


### PR DESCRIPTION
This is finally bringing in work from @vannidellaricca that took place in #35 

The original PR suggested to make only one replacement instead of every replacement. This one is still [problematic](https://github.com/stellarwp/assets/actions/runs/21399443863/job/61606161019?pr=46).

What i implemented instead is order by longest to shortest the `base_dirs`. Perform replacement one by one until a replacement is done.

This ensures that the existing tests continue to pass, while also makes the new added tests pass.